### PR TITLE
Circumvent view:cache on local and add config to do it on other environments; document this.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ return axios.get(route('posts.show', {id: postId}))
     });
 ```
 
+## Caching
+Laravel caches views by default, so we're circumventing View caching by default when `config('app.env')` is `local`.
+If you want to do this in some other environment for some reason, just set `ziggy_cache` to `false` in your `config/app.php`.
+
+If you don't already, we'd recomment making sure you're running `view:clear` when deploying to non-local environments to make sure all your changes get reflected on the server.
+
+
 ## Credits
 
 Author: [Daniel Coulbourne](https://twitter.com/DCoulbourne)

--- a/src/NoCacheBladeCompiler.php
+++ b/src/NoCacheBladeCompiler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tightenco\Ziggy;
+
+use Illuminate\View\Compilers\BladeCompiler;
+
+class NoCacheBladeCompiler extends BladeCompiler
+{
+	public function isExpired($path)
+	{
+		return true;
+	}
+}

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -4,11 +4,21 @@ namespace Tightenco\Ziggy;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Tightenco\Ziggy\NoCacheBladeCompiler;
+use Tightenco\Ziggy\UnCachedViewFinder;
 
 class ZiggyServiceProvider extends ServiceProvider
 {
     public function boot(BladeRouteGenerator $generator)
     {
+        if (config('app.env') === 'local' || config('app.ziggy_cache') === false) {
+            $this->app->singleton('blade.compiler', function () {
+                return new NoCacheBladeCompiler(
+                    $this->app['files'], $this->app['config']['view.compiled']
+                );
+            });
+        }
+
         Blade::directive('routes', function () use ($generator) {
             return $generator->generate();
         });


### PR DESCRIPTION
This is a big win for the package. Before you had to run `view:clear` on each update to your routes file.

Brings up the idea of selectively circumventing caching only when our directive is called.
I'll work on that soon.