### PR TITLE
Re-work how base url is generated

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -16,15 +16,15 @@ class BladeRouteGenerator
 
     public function generate()
     {
-        $json = (string) $this->nameKeyedRoutes();
-        $appUrl = rtrim(config('app.url'), '/') . '/';
+        $json = $this->nameKeyedRoutes()->toJson();
+        $appUrl = url('/') . '/';
         $routeFunction = file_get_contents(__DIR__ . '/js/route.js');
 
         return <<<EOT
 <script type="text/javascript">
     var namedRoutes = JSON.parse('$json'),
         baseUrl = '$appUrl';
-    $routeFunction
+        $routeFunction
 </script>
 EOT;
     }


### PR DESCRIPTION
Fixes #26 

Uses Laravel `route()` helper to take advantage of its default understanding of URL even if it's not set in `.env`