### PR TITLE
Don't pick methods property

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -33,7 +33,7 @@ EOT;
     {
         return collect($this->router->getRoutes()->getRoutesByName())
             ->map(function ($route) {
-                return collect($route)->only(['uri', 'methods'])
+                return collect($route)->only(['uri'])
                     ->put('domain', $route->domain());
             });
     }


### PR DESCRIPTION
I could not find any usage of `methods` property, so removing it.
This will save some bytes on generated html page.