### PR TITLE
Fix optional route parameters

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -1,5 +1,5 @@
 var route = function(name, params, absolute) {
-    if (params === undefined) params = {}; 
+    if (params === undefined) params = {};
     if (absolute === undefined) absolute = true;
 
     var domain = (namedRoutes[name].domain || baseUrl).replace(/\/+$/,'') + '/',
@@ -10,12 +10,16 @@ var route = function(name, params, absolute) {
     return url.replace(
         /\{([^}]+)\}/gi,
         function (tag) {
-            var key = Array.isArray(params) ? paramsArrayKey : tag.replace(/\{|\}/gi, '');
+            var key = Array.isArray(params) ? paramsArrayKey : tag.replace(/\{|\}/gi, '').replace(/\?$/, '');
             paramsArrayKey++;
-            if (params[key] === undefined) {
-                throw 'Ziggy Error: "' + key + '" key is required for route "' + name + '"';
+            if (typeof params[key] !== 'undefined') {
+              return params[key].id || params[key];
             }
-            return params[key].id || params[key];
+            if (tag.indexOf('?') === -1) {
+              throw 'Ziggy Error: "' + key + '" key is required for route "' + name + '"';
+            } else {
+              return '';
+            }
         }
     );
 }

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var route = require('../../src/js/route');
 
-namedRoutes = JSON.parse('{"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"team.user.show":{"uri":"users\/{id}","methods":["GET","HEAD"],"domain":"{team}.myapp.dev"},"posts.index":{"uri":"posts","methods":["GET","HEAD"],"domain":null},"posts.show":{"uri":"posts\/{id}","methods":["GET","HEAD"],"domain":null},"posts.update":{"uri":"posts\/{id}","methods":["PUT"],"domain":null},"posts.store":{"uri":"posts","methods":["POST"],"domain":null},"posts.destroy":{"uri":"posts\/{id}","methods":["DELETE"],"domain":null},"events.venues.show":{"uri":"events\/{event}\/venues\/{venue}","methods":["GET","HEAD"],"domain":null}}'),
+namedRoutes = JSON.parse('{"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"team.user.show":{"uri":"users\/{id}","methods":["GET","HEAD"],"domain":"{team}.myapp.dev"},"posts.index":{"uri":"posts","methods":["GET","HEAD"],"domain":null},"posts.show":{"uri":"posts\/{id}","methods":["GET","HEAD"],"domain":null},"posts.update":{"uri":"posts\/{id}","methods":["PUT"],"domain":null},"posts.store":{"uri":"posts","methods":["POST"],"domain":null},"posts.destroy":{"uri":"posts\/{id}","methods":["DELETE"],"domain":null},"events.venues.show":{"uri":"events\/{event}\/venues\/{venue}","methods":["GET","HEAD"],"domain":null},"optional":{"uri":"optional\/{id}\/{slug?}","methods":["GET","HEAD"],"domain":null}}'),
     baseUrl = 'http://myapp.dev/';
 
 describe('route()', function() {
@@ -85,5 +85,19 @@ describe('route()', function() {
             "http://myapp.dev/",
             route.route('home')
         );
+    });
+
+    it('Should skip the optional parameter `slug`', function() {
+      assert.equal(
+        route.route('optional', { id: 123}),
+        'http://myapp.dev/optional/123/'
+      )
+    });
+
+    it('Should accept the optional parameter `slug`', function() {
+      assert.equal(
+        route.route('optional', { id: 123, slug:'news'}),
+        'http://myapp.dev/optional/123/news'
+      )
     });
 });


### PR DESCRIPTION
### Highlights -
* Make optional route parameter optional

The solution is little ugly, but works well.
Feel free to [refactor](https://help.github.com/articles/checking-out-pull-requests-locally/).

### Here are some samples -
```php
// routes/web.php
Route::get('/test/{id}/{next}/{from?}')->name('test');
```
```js
//  will throw error about missing id parameter only
route('test')

//  works well, skipping `from` parameter
route('test', { id : 123, next : 'checkout'} );
// http://domain.dev/test/123/checkout

//  works well with all parameters
route('test', { id : 123, from : 'product', next : 'checkout' });
// http://domain.dev/test/123/checkout/product
```
Ref: #31

P.S. Add tests
Thanks.
