### PR TITLE
Add support for whole object params

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ route('posts.index') // Returns '/posts'
 With required parameter:
 
 ```js
-route('posts.show')
-route('posts.show', {id: 1})
+route('posts.show', {id: 1}) // Returns '/posts/1'
 route('posts.show', [1]) // Returns '/posts/1'
 route('posts.show', 1) // Returns '/posts/1'
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Ziggy creates a Blade directive which you can include in your views. This will export a JavaScript object of your application's named routes, keyed by their names (aliases), as well as a global `route()` helper function which you can use to access your routes in your JavaScript.
 
-## Installation 
+## Installation
 
 1. Add Ziggy to your Composer file: `composer require tightenco/ziggy`
 
@@ -20,22 +20,47 @@ Ziggy creates a Blade directive which you can include in your views. This will e
 
 This package replaces the `@routes` directive with a collection of all of your application's routes, keyed by their names. This collection is available at `window.namedRoutes`.
 
-The package also creates an optional `route()` JavaScript helper which functions like Laravel's `route()` PHP helper, which can be used to retrieve URLs by name and (optionally) parameters. 
+The package also creates an optional `route()` JavaScript helper which functions like Laravel's `route()` PHP helper, which can be used to retrieve URLs by name and (optionally) parameters.
 
-For example:
+### Examples:
 
-`route('posts.index')` should return `posts`
+Without parameters:
 
-If you wish to retrieve the URL for a route with required parameters, pass a JavaScript object with the parameterss as the second argument to `route()`:
+```js
+route('posts.index') // Returns '/posts'
+```
 
-`route('posts.show', {id: 1})` should return `posts/1`
+With required parameter:
 
-Here's a full example:
+```js
+route('posts.show')
+route('posts.show', {id: 1})
+route('posts.show', [1]) // Returns '/posts/1'
+route('posts.show', 1) // Returns '/posts/1'
+```
+
+With multiple required parameters:
+
+```js
+route('events.venues.show', {event: 1, venue: 2}) // Returns '/events/1/venues/2'
+route('events.venues.show', [1, 2]) // Returns '/events/1/venues/2'
+```
+
+If whole objects are passed, Ziggy will automatically look for `id` primary key:
+
+```js
+var event = {id: 1, name: 'World Series'};
+var venue = {id: 2, name: 'Rogers Centre'};
+
+route('events.venues.show', [event, venue]) // Returns '/events/1/venues/2'
+```
+
+Practical AJAX example:
 
 ```javascript
-let postId = 1337;
+var post = {id: 1, title: 'Ziggy Stardust'};
 
-return axios.get(route('posts.show', {id: postId}))
+return axios.get(route('posts.show', post))
     .then((response) => {
         return response.data;
     });

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -12,7 +12,7 @@ var route = function(name, params = {}, absolute = true) {
             if (params[key] === undefined) {
                 throw 'Ziggy Error: "' + key + '" key is required for route "' + name + '"';
             }
-            return params[key];
+            return params[key].id || params[key];
         }
     );
 }

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -54,6 +54,25 @@ describe('route()', function() {
         );
     });
 
+    it('Should return URL when run with whole object params on a route with required params', function() {
+        var event = {id: 1, name: 'World Series'};
+        var venue = {id: 2, name: 'Rogers Centre'};
+
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show', [event, venue])
+        );
+    });
+
+    it('Should return URL when run with some whole object params on a route with required params', function() {
+        var venue = {id: 2, name: 'Rogers Centre'};
+
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show', [1, venue])
+        );
+    });
+
     it('Should return correct URL when run with params on a route with required domain params', function() {
         assert.equal(
             "tighten.myapp.dev/users/1",


### PR DESCRIPTION
Adds support for whole object params, as discussed in #28.

```js
var event = {id: 123, name: 'World Series'};
var venue = {id: 456, name: 'Rogers Centre'};

route('events.venues.show', [event, venue])
// Outputs "http://myapp.dev/events/123/venues/456"
```

And support for mixed object and non-object params:

```js
var venue = {id: 456, name: 'Rogers Centre'};

route('events.venues.show', [123, venue])
// Outputs "http://myapp.dev/events/123/venues/456"
```

### Note on custom primary keys...

I realize a Laravel `Model` can be configured with a custom primary key, ie)

```php
class Post extends Model
{
    protected $primaryKey = 'uuid';
}
```

However, this could get complicated (especially if each model has a different primary key configuration) and might likely require some kind of Ziggy config array mapping.  I'm thinking this PR is a step in the right direction for now, at least for those who follow Laravel's `id` convention.  I would be interested in attempting custom primary keys in a separate PR though.  Thoughts?