### PR TITLE
Filter routes with optional whitelist and blacklist configs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ return axios.get(route('posts.show', {id: postId}))
     });
 ```
 
+## Filtering Routes
+
+Filtering routes is *completely* optional. If you want to pass all of your routes to JavaScript by default, you can carry on using Ziggy as described above.
+
+If you do want to filter routes, we have provided two optional configuration settings to allow you to do so. To take advantage of these, create a standard config file called `ziggy.php` in the `config/` directory of your Laravel app and set **either** the `whitelist` or `blacklist` setting to an array of route names.
+
+**Note: You've got to choose one or the other. Setting `whitelist` and `blacklist` will disable filtering altogether and simple return the default list of routes.**
+
+#### Example `config/ziggy.php`
+```php
+<?php
+[
+	// 'whitelist' => ['home', 'api.*'],
+	'blacklist' => ['admin.*', 'vulnerabilities.*'],
+]
+```
+
+As shown in the example above, Ziggy the use of asterisks as wildcards in filters. `home` will only match the route named `home` whereas `api.*` will match any route whose name begins with `api.`, such as `api.posts.index` and `api.users.show`.
 
 ## Credits
 

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -7,16 +7,17 @@ use Illuminate\Routing\Router;
 class BladeRouteGenerator
 {
     private $router;
-    public $routes;
+    public $routePayload;
 
     public function __construct(Router $router)
     {
         $this->router = $router;
+        $this->routePayload = RoutePayload::compile($this->router);
     }
 
     public function generate()
     {
-        $json = $this->nameKeyedRoutes()->toJson();
+        $json = $this->routePayload->toJson();
         $appUrl = url('/') . '/';
         $routeFunction = file_get_contents(__DIR__ . '/js/route.js');
 
@@ -27,14 +28,5 @@ class BladeRouteGenerator
         $routeFunction
 </script>
 EOT;
-    }
-
-    public function nameKeyedRoutes()
-    {
-        return collect($this->router->getRoutes()->getRoutesByName())
-            ->map(function ($route) {
-                return collect($route)->only(['uri', 'methods'])
-                    ->put('domain', $route->domain());
-            });
     }
 }

--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tightenco\Ziggy;
+
+use Illuminate\Routing\Router;
+
+class RoutePayload
+{
+    protected $routes;
+
+    public function __construct(Router $router)
+    {
+        $this->router = $router;
+        $this->routes = $this->nameKeyedRoutes();
+    }
+
+    static public function compile(Router $router)
+    {
+        return (new RoutePayload($router))->applyFilters();
+    }
+
+    public function applyFilters()
+    {
+        // return unfiltered routes if user set both config options.
+        if (config()->has('ziggy.blacklist') && config()->has('ziggy.whitelist')) {
+            return $this->routes; 
+        }
+
+        if (config()->has('ziggy.blacklist')) {
+            return $this->blacklist();
+        }
+
+        if (config()->has('ziggy.whitelist')) {
+            return $this->whitelist();
+        }
+
+        return $this->routes;
+    }
+
+    public function blacklist()
+    {
+        return $this->filter(config('ziggy.blacklist'), false);
+    }
+
+    public function whitelist()
+    {
+        return $this->filter(config('ziggy.whitelist'), true);
+    }
+
+    public function filter($filters = [], $include = true)
+    {
+        return $this->routes->filter(function ($route, $name) use ($filters, $include) {
+            foreach ($filters as $filter) {
+                if (str_is($filter, $name)) {
+                    return $include;
+                }
+            }
+
+            return ! $include;
+        });
+    }
+
+    protected function nameKeyedRoutes()
+    {
+        return collect($this->router->getRoutes()->getRoutesByName())
+            ->map(function ($route) {
+                return collect($route)->only(['uri', 'methods'])
+                    ->put('domain', $route->domain());
+            });
+    }
+}

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -39,7 +39,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
             ],
-        ], $generator->nameKeyedRoutes()->toArray());
+        ], $generator->routePayload->toArray());
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
             ],
-        ], $generator->nameKeyedRoutes()->toArray());
+        ], $generator->routePayload->toArray());
     }
 
     /** @test */
@@ -88,7 +88,7 @@ class BladeRouteGeneratorTest extends TestCase
 
         $generator = (new BladeRouteGenerator($router));
 
-        $array = $generator->nameKeyedRoutes()->toArray();
+        $array = $generator->routePayload->toArray();
 
         $this->assertCount(4, $array);
 

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tightenco\Tests\Unit;
+
+use Illuminate\Container\Container;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Route;
+use Tightenco\Tests\TestCase;
+use Tightenco\Ziggy\BladeRouteGenerator;
+use Tightenco\Ziggy\RoutePayload;
+
+class RoutePayloadTest extends TestCase
+{
+    protected $router;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->router = app('router');
+        $this->router->get('/home', function () { return ''; })
+               ->name('home');
+
+        $this->router->get('/posts', function () { return ''; })
+               ->name('posts.index');
+
+        $this->router->get('/posts/{post}', function () { return ''; })
+               ->name('posts.show');
+
+        $this->router->get('/posts/{post}/comments', function () { return ''; })
+               ->name('postComments.index');
+
+        $this->router->post('/posts', function () { return ''; })
+               ->name('posts.store');
+
+        $this->router->getRoutes()->refreshNameLookups();
+    }
+
+    /** @test */
+    public function only_matching_routes_included_with_whitelist_enabled()
+    {
+        $routePayload = new RoutePayload($this->router);
+        $filters = ['posts.s*', 'home'];
+        $routes = $routePayload->filter($filters, true);
+
+        $expected = [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+
+    /** @test */
+    public function only_matching_routes_excluded_with_blacklist_enabled()
+    {
+        $routePayload = new RoutePayload($this->router);
+        $filters = ['posts.s*', 'home'];
+        $routes = $routePayload->filter($filters, false);
+
+        $expected = [
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+
+    /** @test */
+    public function existance_of_whitelist_config_causes_routes_to_whitelist()
+    {
+        app()['config']->set('ziggy', [
+            'whitelist' => ['posts.s*', 'home']
+        ]);
+
+        $routes = RoutePayload::compile($this->router);
+
+        $expected = [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+
+    /** @test */
+    public function existance_of_blacklist_config_causes_routes_to_blacklist()
+    {
+        app()['config']->set('ziggy', [
+            'blacklist' => ['posts.s*', 'home']
+        ]);
+
+        $routes = RoutePayload::compile($this->router);
+
+        $expected = [
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+
+    /** @test */
+    public function existance_of_both_configs_returns_unfiltered_routes()
+    {
+        app()['config']->set('ziggy', [
+            'blacklist' => ['posts.s*'],
+            'whitelist' => ['home'],
+        ]);
+
+        $routes = RoutePayload::compile($this->router);
+
+        $expected = [
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+}


### PR DESCRIPTION
## Filtering Routes

Filtering routes is *completely* optional. If you want to pass all of your routes to JavaScript by default, you can carry on using Ziggy as described above.

If you do want to filter routes, we have provided two optional configuration settings to allow you to do so. To take advantage of these, create a standard config file called `ziggy.php` in the `config/` directory of your Laravel app and set **either** the `whitelist` or `blacklist` setting to an array of route names.

**Note: You've got to choose one or the other. Setting `whitelist` and `blacklist` will disable filtering altogether and simple return the default list of routes.**

#### Example `config/ziggy.php`
```php
<?php
[
	// 'whitelist' => ['home', 'api.*'],
	'blacklist' => ['admin.*', 'vulnerabilities.*'],
]
```

As shown in the example above, Ziggy the use of asterisks as wildcards in filters. `home` will only match the route named `home` whereas `api.*` will match any route whose name begins with `api.`, such as `api.posts.index` and `api.users.show`.

## Other notes:

For cleanliness, I went ahead and pulled all the route manipulation code out into a separate class called `Tightenco\Ziggy\RoutePayload`. This makes the `BladeRouteGenerator` less of a god object and opens the door for more `SomethingRouteGenerator` classes down the road to use the RoutePayload. (API endpoints anyone?)

## Issues
Closes #16 