### PR TITLE
Strip leading slash from route URI.

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -1,6 +1,6 @@
 var route = function(name, params = {}, absolute = true) {
     var domain = (namedRoutes[name].domain || baseUrl).replace(/\/+$/,'') + '/',
-        url = (absolute ? domain : '') + namedRoutes[name].uri,
+        url = (absolute ? domain : '') + namedRoutes[name].uri.replace(/^\//, ''),
         params = typeof params !== 'object' ? [params] : params,
         paramsArrayKey = 0;
 

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -60,4 +60,11 @@ describe('route()', function() {
             route.route('team.user.show', {team: 'tighten', id: 1})
         );
     });
+
+    it('Should return base url if path is "/"', function() {
+        assert.equal(
+            "http://myapp.dev/",
+            route.route('home')
+        );
+    });
 });


### PR DESCRIPTION
@ctf0 discovered a bug ( closes #27 ) where a route with the url of `/` was returning as `app.com//`

This appears to be because that path is the only one which Laravel does not strip of its leading slash.

This automatically strips leading slashes from URIs.