### PR TITLE
Optional whitelist groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ return axios.get(route('posts.show', post))
 ```
 
 ## Filtering Routes
-
 Filtering routes is *completely* optional. If you want to pass all of your routes to JavaScript by default, you can carry on using Ziggy as described above.
 
-If you do want to filter routes, we have provided two optional configuration settings to allow you to do so. To take advantage of these, create a standard config file called `ziggy.php` in the `config/` directory of your Laravel app and set **either** the `whitelist` or `blacklist` setting to an array of route names.
+### Basic Whitelisting & Blacklisting
+To take advantage of basic whitelisting or blacklisting of routes, you will first need to create a standard config file called `ziggy.php` in the `config/` directory of your Laravel app and set **either** the `whitelist` or `blacklist` setting to an array of route names.
 
 **Note: You've got to choose one or the other. Setting `whitelist` and `blacklist` will disable filtering altogether and simply return the default list of routes.**
 
-#### Example `config/ziggy.php`
+#### Example `config/ziggy.php`:
 ```php
 <?php
 return [
@@ -83,6 +83,33 @@ return [
 ```
 
 As shown in the example above, Ziggy the use of asterisks as wildcards in filters. `home` will only match the route named `home` whereas `api.*` will match any route whose name begins with `api.`, such as `api.posts.index` and `api.users.show`.
+
+### Advanced Whitelisting Using Groups
+
+You may also optionally define multiple whitelists by defining `groups` in your `config/ziggy.php`:
+
+```php
+<?php
+return [
+    'groups' => [
+        'admin' => [
+            'admin.*',
+            'posts.*',
+        ]
+        'author' => [
+            'posts.*',
+        ]
+    ],
+];
+```
+
+In the above example, you can see we have configured multiple whitelists for different user roles.  You may expose a specific whitelist group by passing the group key into `@route` within your blade view.  Example:
+
+```php
+@route('author')
+```
+
+**Note: Using a group will always take precedence over the above mentioned `whitelist` and `blacklist` settings.**
 
 ## Contributions & Credits
 

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -12,12 +12,16 @@ class BladeRouteGenerator
     public function __construct(Router $router)
     {
         $this->router = $router;
-        $this->routePayload = RoutePayload::compile($this->router);
     }
 
-    public function generate()
+    public function getRoutePayload($group = false)
     {
-        $json = $this->routePayload->toJson();
+        return RoutePayload::compile($this->router, $group);
+    }
+
+    public function generate($group = false)
+    {
+        $json = $this->getRoutePayload($group)->toJson();
         $appUrl = url('/') . '/';
         $routeFunction = file_get_contents(__DIR__ . '/js/route.js');
 

--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -14,16 +14,20 @@ class RoutePayload
         $this->routes = $this->nameKeyedRoutes();
     }
 
-    static public function compile(Router $router)
+    public static function compile(Router $router, $group = false)
     {
-        return (new RoutePayload($router))->applyFilters();
+        return (new static($router))->applyFilters($group);
     }
 
-    public function applyFilters()
+    public function applyFilters($group)
     {
+        if ($group && config()->has("ziggy.groups.{$group}")) {
+            return $this->group($group);
+        }
+
         // return unfiltered routes if user set both config options.
         if (config()->has('ziggy.blacklist') && config()->has('ziggy.whitelist')) {
-            return $this->routes; 
+            return $this->routes;
         }
 
         if (config()->has('ziggy.blacklist')) {
@@ -35,6 +39,11 @@ class RoutePayload
         }
 
         return $this->routes;
+    }
+
+    public function group($group)
+    {
+        return $this->filter(config("ziggy.groups.{$group}"), true);
     }
 
     public function blacklist()

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -9,8 +9,8 @@ class ZiggyServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Blade::directive('routes', function () {
-            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate(); ?>";
+        Blade::directive('routes', function ($group) {
+            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
         });
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -39,7 +39,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
             ],
-        ], $generator->routePayload->toArray());
+        ], $generator->getRoutePayload()->toArray());
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
             ],
-        ], $generator->routePayload->toArray());
+        ], $generator->getRoutePayload()->toArray());
     }
 
     /** @test */
@@ -88,7 +88,7 @@ class BladeRouteGeneratorTest extends TestCase
 
         $generator = (new BladeRouteGenerator($router));
 
-        $array = $generator->routePayload->toArray();
+        $array = $generator->getRoutePayload()->toArray();
 
         $this->assertCount(4, $array);
 


### PR DESCRIPTION
After some discussion in #16, here's my PR for optional whitelist groups.  It's tested and documented, but here's a quick rundown of my implementation:

If you add `groups` to your ziggy config file:

```php
return [
    'groups' => [
        'admin' => [
            'admin.*',
            'posts.*',
        ]
        'author' => [
            'posts.*',
        ]
    ],
];
```

You essentially have multiple whitelists.  Using the `@routes` blade directive without a parameter behaves as it always did.  However, you can pass a group key like `@routes('author')` to only expose the whitelisted routes in that specific group.  This can be helpful if you have multiple user roles and want more control over which routes you expose in each user dashboard.

**Note:** The existing `whitelist` and `blacklist` features still behave as expected, though if you expose a specific `group`, it will take precedence over `whitelist` and `blacklist` 👍 

Thoughts? 🙂