### PR TITLE
Break router out into a class, including optional fluent `with()` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/tightenco/ziggy#readme",
   "devDependencies": {
-    "mocha": "^3.5.0"
+    "axios": "^0.16.2",
+    "mocha": "^3.5.0",
+    "moxios": "^0.4.0"
   }
 }

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -1,23 +1,57 @@
-var route = function(name, params, absolute) {
-    if (params === undefined) params = {}; 
-    if (absolute === undefined) absolute = true;
+var Router = function(name, params, absolute) {
+    this.name = name;
+    this.params = params === undefined ? {} : params;
+    this.absolute = absolute === undefined ? true : absolute;
+    this.domain = this.constructDomain();
+    this.url = namedRoutes[this.name].uri.replace(/^\//, '');
 
-    var domain = (namedRoutes[name].domain || baseUrl).replace(/\/+$/,'') + '/',
-        url = (absolute ? domain : '') + namedRoutes[name].uri.replace(/^\//, ''),
-        params = typeof params !== 'object' ? [params] : params,
-        paramsArrayKey = 0;
+    this.return = '';
 
+};
+
+Router.prototype.toString = function() {
+    this.parse();
+    return this.return;
+};
+
+Router.prototype.constructDomain = function() {
+    if (this.absolute)
+        return (namedRoutes[this.name].domain || baseUrl).replace(/\/+$/,'') + '/';
+
+    return '';
+};
+
+Router.prototype.with = function(params) {
+    this.params = params;
+
+    return this;
+};
+
+Router.prototype.parse = function() {
+    this.return = this.constructUrl();
+};
+
+Router.prototype.constructUrl = function() {
+    tags = typeof this.params !== 'object' ? [this.params] : this.params,
+    paramsArrayKey = 0;
+    var url = this.domain + this.url;
     return url.replace(
         /\{([^}]+)\}/gi,
         function (tag) {
-            var key = Array.isArray(params) ? paramsArrayKey : tag.replace(/\{|\}/gi, '');
+            var keyName = tag.replace(/\{|\}/gi, '');
+            var key = Array.isArray(tags) ? paramsArrayKey : keyName;
+
             paramsArrayKey++;
-            if (params[key] === undefined) {
-                throw 'Ziggy Error: "' + key + '" key is required for route "' + name + '"';
+            if (tags[key] === undefined) {
+                throw 'Ziggy Error: "' + keyName + '" key is required for route "' + this.name + '"';
             }
-            return params[key].id || params[key];
+            return tags[key].id || tags[key];
         }
     );
 }
+
+var route = function(name, params, absolute) {
+    return new Router(name, params, absolute);
+};
 
 if (typeof exports !== 'undefined'){ exports.route = route }

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -14,7 +14,7 @@ describe('route()', function() {
 
     it('Should return missing params error when run with missing params on a route with required params', function() {
         assert.throws(
-            function(){ route.route('posts.show')},
+            function(){route.route('posts.show').toString()},
             /\"id\" key is required/
         );
     });
@@ -24,12 +24,20 @@ describe('route()', function() {
             "http://myapp.dev/posts/1",
             route.route('posts.show', 1)
         );
+        assert.equal(
+            "http://myapp.dev/posts/1",
+            route.route('posts.show').with(1)
+        );
     });
 
     it('Should return URL when run with single object param on a route with required params', function() {
         assert.equal(
             "http://myapp.dev/posts/1",
             route.route('posts.show', {id: 1})
+        );
+        assert.equal(
+            "http://myapp.dev/posts/1",
+            route.route('posts.show').with({id: 1})
         );
     });
 
@@ -38,6 +46,10 @@ describe('route()', function() {
             "http://myapp.dev/posts/1",
             route.route('posts.show', [1])
         );
+        assert.equal(
+            "http://myapp.dev/posts/1",
+            route.route('posts.show').with([1])
+        );
     });
 
     it('Should return URL when run with multiple object params on a route with required params', function() {
@@ -45,12 +57,20 @@ describe('route()', function() {
             "http://myapp.dev/events/1/venues/2",
             route.route('events.venues.show', {event: 1, venue: 2})
         );
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show').with({event: 1, venue: 2})
+        );
     });
 
     it('Should return URL when run with multiple array params on a route with required params', function() {
         assert.equal(
             "http://myapp.dev/events/1/venues/2",
             route.route('events.venues.show', [1, 2])
+        );
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show').with([1, 2])
         );
     });
 
@@ -62,6 +82,10 @@ describe('route()', function() {
             "http://myapp.dev/events/1/venues/2",
             route.route('events.venues.show', [event, venue])
         );
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show').with([event, venue])
+        );
     });
 
     it('Should return URL when run with some whole object params on a route with required params', function() {
@@ -71,12 +95,20 @@ describe('route()', function() {
             "http://myapp.dev/events/1/venues/2",
             route.route('events.venues.show', [1, venue])
         );
+        assert.equal(
+            "http://myapp.dev/events/1/venues/2",
+            route.route('events.venues.show').with([1, venue])
+        );
     });
 
     it('Should return correct URL when run with params on a route with required domain params', function() {
         assert.equal(
             "tighten.myapp.dev/users/1",
             route.route('team.user.show', {team: 'tighten', id: 1})
+        );
+        assert.equal(
+            "tighten.myapp.dev/users/1",
+            route.route('team.user.show').with({team: 'tighten', id: 1})
         );
     });
 

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -1,4 +1,6 @@
 var assert = require('assert');
+var axios = require('axios');
+var moxios = require('moxios');
 var route = require('../../src/js/route');
 
 namedRoutes = JSON.parse('{"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"team.user.show":{"uri":"users\/{id}","methods":["GET","HEAD"],"domain":"{team}.myapp.dev"},"posts.index":{"uri":"posts","methods":["GET","HEAD"],"domain":null},"posts.show":{"uri":"posts\/{id}","methods":["GET","HEAD"],"domain":null},"posts.update":{"uri":"posts\/{id}","methods":["PUT"],"domain":null},"posts.store":{"uri":"posts","methods":["POST"],"domain":null},"posts.destroy":{"uri":"posts\/{id}","methods":["DELETE"],"domain":null},"events.venues.show":{"uri":"events\/{event}\/venues\/{venue}","methods":["GET","HEAD"],"domain":null}}'),
@@ -117,5 +119,19 @@ describe('route()', function() {
             "http://myapp.dev/",
             route.route('home')
         );
+    });
+
+    it('Should make an axios call when a route() is passed', function() {
+        moxios.install()
+        moxios.stubRequest('http://myapp.dev/posts/1', {
+            status: 200,
+            responseText: 'Worked!'
+        });
+
+        axios.get(route.route('posts.show', 1)).then(function(response) {
+            assert.equal(200, response.status)
+        });
+
+        moxios.uninstall()
     });
 });


### PR DESCRIPTION
This is basically a housekeeping update to begin the transition to using object methods in the Router. This allows us to create fluent chainable methods on the base.

This PR implements `route().with()` which accepts all the same input as the `params` argument of the existing `route()` function.

It's purely cosmetic an exists as a proof of concept. I'm not going to document it yet, just in case we decide that fluency for core functionality is a bad idea.

Currently works like so: 
```javascript
route('team.user.show').with({team: 'tighten', id: 1})
```

I will soon add `withQuery` and `withDomain` methods as well. I still intend to fit queries into the base function arguments somehow to achieve feature parity with Laravel as best as possible, but I think this provides a nice alternative for folks who have a hard time parsing what is going on visually.