### PR TITLE
Reimplement absolute param

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -18,15 +18,15 @@ Router.prototype.normalizeParams = function(params) {
 };
 
 Router.prototype.constructDomain = function() {
-    if(this.name === undefined) {
+    if (this.name === undefined) {
         throw 'Ziggy Error: You must provide a route name';
-    }
-    else if (namedRoutes[this.name] === undefined) {
+    } else if (namedRoutes[this.name] === undefined) {
         throw 'Ziggy Error: route "'+ this.name +'" is not found in the route list';
+    } else if (! this.absolute) {
+        return '/';
     }
-    else {
-        return (namedRoutes[this.name].domain || baseUrl).replace(/\/+$/,'') + '/';
-    }
+
+    return (namedRoutes[this.name].domain || baseUrl).replace(/\/+$/,'') + '/';
 };
 
 Router.prototype.with = function(params) {

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -14,6 +14,13 @@ describe('route()', function() {
         );
     });
 
+    it('Should return URL without domain when passing false into absolute param.', function() {
+        assert.equal(
+            "/posts",
+            route('posts.index', [], false)
+        );
+    });
+
     it('Should return missing params error when run with missing params on a route with required params', function() {
         assert.throws(
             function() {


### PR DESCRIPTION
Fixes absolute param regression from #57.
Adds test coverage to ensure functionality matches Laravel's functionality.

```js
route('posts.show', 1) // returns 'http://myapp.dev/posts/1'
route('posts.show', 1, false) // returns '/posts/1'
```