### PR TITLE
Add test case for string type

### DIFF
--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -7,6 +7,14 @@ namedRoutes = JSON.parse('{"home":{"uri":"\/","methods":["GET","HEAD"],"domain":
 baseUrl = 'http://myapp.dev/';
 
 describe('route()', function() {
+
+    it('Should return `string` type upon success', function() {
+      assert.equal(
+        "string",
+        typeof route('posts.index')
+      );
+    });
+
     it('Should return URL when run without params on a route without params', function() {
         assert.equal(
             "http://myapp.dev/posts",


### PR DESCRIPTION
Version 0.4.0 is no longer working for me. 
I rolled back to 0.3.0.

When i run `route("valid-route")` in console, it returns `object` rather url (string).
So i am adding a test case for future proofing.

The `route()` method is expected to return string types if everything goes well.

Something is wrong with existing test cases. Don't know how they get passed.
May be choose a different assertion library.

