### PR TITLE
[0.4.0] Add test for axios query params

### DIFF
--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -147,6 +147,24 @@ describe('route()', function() {
         moxios.uninstall()
     });
 
+    it('Should make an axios call with query params when a route() is passed', function(done) {
+      moxios.install();
+
+      moxios.stubRequest('http://myapp.dev/posts/1', {
+        status: 200,
+        responseText: "Worked!"
+      });
+
+      axios
+        .get(route('posts.show', 1),{params:{page:1}})
+        .then(function(response) {
+          assert.equal(200, response.status);
+          done();
+        });
+
+      moxios.uninstall()
+    });
+
     it('Should skip the optional parameter `slug`', function() {
       assert.equal(
         route('optional', { id: 123 }),


### PR DESCRIPTION
Seems like i found the issue.

It is not working with `axios` when we pass `params` as second parameter
```js
axios.get(route('posts.index'), {
  params: { page: 2 }
})
```
This is just one case, there may be hidden scenarios.

I was able to fix it by calling ``toString()`` but this is not the best way to fix this.
 ```js
axios.get(route('posts.index').toString(), {
  params: { page: 2}
})
```
I think we should stick to return string type.


