### PR TITLE
[0.4.1] Add String passthrough to handle edge-cases.

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -5,7 +5,13 @@ var Router = function(name, params, absolute) {
     this.absolute = absolute === undefined ? true : absolute;
     this.domain = this.constructDomain();
     this.url = namedRoutes[this.name].uri.replace(/^\//, '');
+
+    String.call(this);
 };
+
+
+Router.prototype = Object.create(String.prototype);
+Router.prototype.constructor = Router;
 
 Router.prototype.normalizeParams = function(params) {
     if (params === undefined)
@@ -81,6 +87,11 @@ Router.prototype.constructQuery = function() {
 };
 
 Router.prototype.toString = function() {
+    this.parse();
+    return this.return;
+};
+
+Router.prototype.valueOf = function() {
     this.parse();
     return this.return;
 };

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -142,6 +142,31 @@ describe('route()', function() {
             .get(route('posts.show', 1))
             .then(function(response) {
                 assert.equal(200, response.status)
+            }).catch(function(error) {
+                throw error;
+            });
+
+        moxios.uninstall()
+    });
+
+    it('Should make an axios call when a route() and params are passed', function() {
+        moxios.install();
+
+        moxios.stubRequest('http://myapp.dev/posts/1', {
+            status: 200,
+            responseText: "Worked!"
+        });
+
+        axios.get(route('posts.index'), {
+              page: 2,
+              params: { thing: 'thing'}
+            })
+            .then(function(response) {
+                assert.equal(200, response.status)
+
+            }).catch(function(error) {
+                console.log(error);
+                assert.equal(true, false);
             });
 
         moxios.uninstall()


### PR DESCRIPTION
@ankurk91 This should fix the behavior you were seeing before. We are now extending the `String()` prototype so any unrecognized methods will be passed along to String.

Basically Router is now a `String` object with a few extra methods.

I added a test to demonstrate axios working with the params object you noted before. Thanks for finding that. The reason it was failing was that Axios uses `url.indexOf` when appending params. So because `Router` didn't have an indexOf method, it failed. Now that `Router` extends `String` it just passes unknown method calls on to String, which handles them.