### PR TITLE
Create Artisan Command to Generate File

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4"
+        "orchestra/testbench": "~3.4",
+        "mikey179/vfsStream": "^1.6"
     },
     "extra": {
         "laravel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,322 @@
+{
+  "name": "ziggy",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.2.5",
+        "is-buffer": "1.1.5"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "moxios": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/moxios/-/moxios-0.4.0.tgz",
+      "integrity": "sha1-/A2ixlR31yXKa5Z51YNw7QxS9Ts=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tightenco\Ziggy;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\Router;
+use Tightenco\Ziggy\BladeRouteGenerator;
+use Tightenco\Ziggy\RoutePayload;
+
+class CommandRouteGenerator extends Command
+{
+    protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js}';
+
+    protected $description = 'Generate js file for inclusing in build process';
+
+    protected $baseUrl;
+    protected $baseProtocol;
+    protected $baseDomain;
+    protected $basePort;
+    protected $router;
+
+    public function __construct(Router $router, Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->router = $router;
+        $this->files = $files;
+    }
+
+    public function handle()
+    {
+        $path = $this->argument('path');
+
+        $generatedRoutes = $this->generate();
+
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $generatedRoutes);
+    }
+
+    public function generate($group = false)
+    {
+        $this->prepareDomain();
+
+        $json = $this->getRoutePayload($group)->toJson();
+
+        return <<<EOT
+    var namedRoutes = JSON.parse('$json'),
+        baseUrl = '{$this->baseUrl}',
+        baseProtocol = '{$this->baseProtocol}',
+        baseDomain = '{$this->baseDomain}',
+        basePort = {$this->basePort};
+
+    export {
+        namedRoutes,
+        baseUrl,
+        baseProtocol,
+        baseDomain,
+        basePort
+    }
+
+EOT;
+    }
+
+    private function prepareDomain()
+    {
+        $url = url('/');
+        $parsedUrl = parse_url($url);
+
+        $this->baseUrl = $url . '/';
+        $this->baseProtocol = array_key_exists('scheme', $parsedUrl) ? $parsedUrl['scheme'] : 'http';
+        $this->baseDomain = array_key_exists('host', $parsedUrl) ? $parsedUrl['host'] : '';
+        $this->basePort = array_key_exists('port', $parsedUrl) ? $parsedUrl['port'] : 'false';
+    }
+
+    public function getRoutePayload($group = false)
+    {
+        return RoutePayload::compile($this->router, $group);
+    }
+
+    protected function makeDirectory($path)
+    {
+        if (! $this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        }
+        return $path;
+    }
+}

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -12,7 +12,7 @@ class CommandRouteGenerator extends Command
 {
     protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js}';
 
-    protected $description = 'Generate js file for inclusing in build process';
+    protected $description = 'Generate js file for including in build process';
 
     protected $baseUrl;
     protected $baseProtocol;

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -4,6 +4,7 @@ namespace Tightenco\Ziggy;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Tightenco\Ziggy\CommandRouteGenerator;
 
 class ZiggyServiceProvider extends ServiceProvider
 {
@@ -12,5 +13,11 @@ class ZiggyServiceProvider extends ServiceProvider
         Blade::directive('routes', function ($group) {
             return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
         });
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                CommandRouteGenerator::class,
+            ]);
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,9 +5,17 @@ namespace Tightenco\Tests;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Tightenco\Ziggy\ZiggyServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
+    protected function getPackageProviders($app)
+    {
+        return [
+            ZiggyServiceProvider::class,
+        ];
+    }
+
     protected function assertJsonContains(array $haystack, array $needle)
     {
         $actual = json_encode(Arr::sortRecursive(

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Artisan;
+use Tightenco\Tests\TestCase;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamWrapper;
+
+class CommandRouteGeneratorTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        vfsStreamWrapper::register();
+        vfsStreamWrapper::setRoot(new vfsStreamDirectory('testDir'));
+    }
+
+    /** @test */
+    function file_is_created_when_ziggy_generate_is_called()
+    {
+        Artisan::call('ziggy:generate', ['path' => vfsStream::url('testDir/ziggy.js')]);
+
+        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('ziggy.js'));
+    }
+
+    /** @test */
+    function file_is_created_with_the_expected_structure_when_named_routes_exist()
+    {
+        $router = app('router');
+
+        $router->get('/posts/{post}/comments', function () { return ''; })
+            ->name('postComments.index');
+
+        $router->getRoutes()->refreshNameLookups();
+
+        Artisan::call('ziggy:generate', ['path' => vfsStream::url('testDir/ziggy.js')]);
+
+        $this->assertFileEquals('./tests/assets/js/ziggy.js', vfsStream::url('testDir/ziggy.js'));
+    }
+}

--- a/tests/assets/js/ziggy.js
+++ b/tests/assets/js/ziggy.js
@@ -1,0 +1,13 @@
+    var namedRoutes = JSON.parse('{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}}'),
+        baseUrl = 'http://localhostmyapp.com/',
+        baseProtocol = 'http',
+        baseDomain = 'localhostmyapp.com',
+        basePort = false;
+
+    export {
+        namedRoutes,
+        baseUrl,
+        baseProtocol,
+        baseDomain,
+        basePort
+    }


### PR DESCRIPTION
Created CommandRouteGenerator, that uses similar logic to BladeRouteGenerator to create a file that has the same content as the blade directive (minus route.js) and exports the vars to be used in another file as described in #22. 

There are duplicated methods / logic between CommandRouteGenerator and BladeRouteGenerator could be extracted to a new RouteGenerator that both CommandRouteGenerator and BladeRouteGenerator extend. But I'm not sure that is necessary unless there may be more generators in the future... Let me know your thoughts on that. 