### PR TITLE
Remove JSON.parse()

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -36,7 +36,7 @@ class BladeRouteGenerator
         return <<<EOT
 <script type="text/javascript">
     var Ziggy = {
-        namedRoutes: JSON.parse('$json'),
+        namedRoutes: $json,
         baseUrl: '{$this->baseUrl}',
         baseProtocol: '{$this->baseProtocol}',
         baseDomain: '{$this->baseDomain}',

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -47,7 +47,7 @@ class CommandRouteGenerator extends Command
 
         return <<<EOT
     var Ziggy = {
-        namedRoutes: JSON.parse('$json'),
+        namedRoutes: $json,
         baseUrl: '{$this->baseUrl}',
         baseProtocol: '{$this->baseProtocol}',
         baseDomain: '{$this->baseDomain}',

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -5,7 +5,7 @@ let moxios = require('moxios');
 import route from '../../src/js/route.js';
 
 global.Ziggy = {
-    namedRoutes: JSON.parse('{"home":{"uri":"\/","methods":["GET","HEAD"],"domain":null},"team.user.show":{"uri":"users\/{id}","methods":["GET","HEAD"],"domain":"{team}.myapp.dev"},"posts.index":{"uri":"posts","methods":["GET","HEAD"],"domain":null},"posts.show":{"uri":"posts\/{id}","methods":["GET","HEAD"],"domain":null},"posts.update":{"uri":"posts\/{id}","methods":["PUT"],"domain":null},"posts.store":{"uri":"posts","methods":["POST"],"domain":null},"posts.destroy":{"uri":"posts\/{id}","methods":["DELETE"],"domain":null},"events.venues.show":{"uri":"events\/{event}\/venues\/{venue}","methods":["GET","HEAD"],"domain":null},"optional":{"uri":"optional\/{id}\/{slug?}","methods":["GET","HEAD"],"domain":null}}'),
+    namedRoutes: {"home":{"uri":"/","methods":["GET","HEAD"],"domain":null},"team.user.show":{"uri":"users/{id}","methods":["GET","HEAD"],"domain":"{team}.myapp.dev"},"posts.index":{"uri":"posts","methods":["GET","HEAD"],"domain":null},"posts.show":{"uri":"posts/{id}","methods":["GET","HEAD"],"domain":null},"posts.update":{"uri":"posts/{id}","methods":["PUT"],"domain":null},"posts.store":{"uri":"posts","methods":["POST"],"domain":null},"posts.destroy":{"uri":"posts/{id}","methods":["DELETE"],"domain":null},"events.venues.show":{"uri":"events/{event}/venues/{venue}","methods":["GET","HEAD"],"domain":null},"optional":{"uri":"optional/{id}/{slug?}","methods":["GET","HEAD"],"domain":null}},
     baseUrl: 'http://myapp.dev/',
     baseProtocol: 'http',
     baseDomain: 'myapp.dev',


### PR DESCRIPTION
I don't think we need `JSON.parse` here.
It works well without parsing.

Another approach could be like -
```html
<script type="text/javascript">
    window.Ziggy = @php echo json_encode([
      'property1' => $variable,
      'property2' => $variable2,
    ]); @endphp
  </script>
```