### PR TITLE
Allow publishing config

### DIFF
--- a/config/ziggy.php
+++ b/config/ziggy.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+
+    //'whitelist' => [],
+    'blacklist' => [],
+    'groups' => []
+];

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -28,5 +28,10 @@ class ZiggyServiceProvider extends ServiceProvider
                 CommandRouteGenerator::class,
             ]);
         }
+
+        $this->publishes([
+            realpath(__DIR__ . '/../config/ziggy.php') => config_path('ziggy.php')
+        ], 'config');
     }
+
 }


### PR DESCRIPTION
This PR will allow publishing default configs. User no need to manually create config file.

These configs will not be used by package unless user publish it.
We can publish config with this command:
```
php artisan vendor:publish --provider="Tightenco\Ziggy\ZiggyServiceProvider" --tag="config"
```

**todo**
* Documentation on how to publish config in readme.md
* Document each of the config property in `config/ziggy.php`, what they do.
* At-least add a note about using one either `blacklist` or `whitelist` property.