### PR TITLE
Register blade directive after resolving service

### DIFF
--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -2,10 +2,9 @@
 
 namespace Tightenco\Ziggy;
 
-use Closure;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Compilers\BladeCompiler;
 
 class ZiggyServiceProvider extends ServiceProvider
 {
@@ -19,8 +18,10 @@ class ZiggyServiceProvider extends ServiceProvider
             return Macro::whitelist($this, $group);
         });
 
-        Blade::directive('routes', function ($group) {
-            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+            $bladeCompiler->directive('routes', function ($group) {
+                return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+            });
         });
 
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
More efficient way (IMHO) to register the blade directive, to make sure it's only registered when `blade.compiler` service is resolved (we're browsing from web and we're rendering blade views already), otherwise we neither need to attach the directive nor resolve the `blade.compiler` at this stage. Using the `Blade::directive` facade will auto resolve the `blade.compiler` service even if we're interacting with the application from CLI through artisan, which in some project setups it may cause some `InvalidArgumentException` exceptions (Route [name] not defined.)