### PR TITLE
Run phpUnit on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ php:
 git:
   depth: 1
 install: 
-  - composer install --no-interaction
+  - composer install --no-interaction --no-suggest
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
   - npm install
 script:
+  - phpunit
   - npm run build
   - npm test
 cache:

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -17,7 +17,7 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $generator = app(BladeRouteGenerator::class);
 
-        $this->assertContains("JSON.parse('[]')", $generator->generate());
+        $this->assertContains("namedRoutes: []", $generator->generate());
     }
 
     /** @test */

--- a/tests/assets/js/ziggy.js
+++ b/tests/assets/js/ziggy.js
@@ -1,5 +1,5 @@
     var Ziggy = {
-        namedRoutes: JSON.parse('{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}}'),
+        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}},
         baseUrl: 'http://localhostmyapp.com/',
         baseProtocol: 'http',
         baseDomain: 'localhostmyapp.com',


### PR DESCRIPTION
Some of php tests are still failing.

`Tests\Unit\CommandRouteGeneratorTest::file_is_created_with_the_expected_structure_when_named_routes_exist`
is failing because of difference in application domain url.
![screenshot from 2017-11-25 12 21 59](https://user-images.githubusercontent.com/6111524/33228201-5106644e-d1db-11e7-8bc4-eaf8c05c998f.png)

 `Tightenco\Tests\Unit\BladeRouteGeneratorTest::generator_at_least_vaguely_works_and_outputs_something_vaguely_right_ish`
is failing because we no longer have `JSON.parse()` method to search into output string.

