### PR TITLE
Add the ability to skip the inclusion of the route function

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -31,7 +31,7 @@ class BladeRouteGenerator
 
         $json = $this->getRoutePayload($group)->toJson();
 
-        $routeFunction = file_get_contents($this->getRouteFilePath());
+        $routeFunction = $this->getRouteFunction();
 
         $defaultParameters = method_exists(app('url'), 'getDefaultParameters') ? json_encode(app('url')->getDefaultParameters()) : '[]';
 
@@ -55,6 +55,14 @@ EOT;
     {
         $isMin = app()->isLocal() ? '' : '.min';
         return __DIR__ . "/../dist/js/route{$isMin}.js";
+    }
+
+    private function getRouteFunction()
+    {
+        if (config()->get('ziggy.skip-route-function')) {
+            return '';
+        }
+        return file_get_contents($this->getRouteFilePath());
     }
 
     private function prepareDomain()


### PR DESCRIPTION
This PR contains a small change to the `@route` Blade directive that allows us to keep the dynamic generation of the routes while bundling the `route` helper function separately (instead of shipping an extra 5KB with every page).

I wrote this in the simplest, backward compatible way without any tests so don't hesitate to close this PR if you want to solve this in a completely different way. ;)