### PR TITLE
CommandRouteGenerator defaultParameters fix

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -44,6 +44,8 @@ class CommandRouteGenerator extends Command
         $this->prepareDomain();
 
         $json = $this->getRoutePayload($group)->toJson();
+        
+        $defaultParameters = method_exists(app('url'), 'getDefaultParameters') ? json_encode(app('url')->getDefaultParameters()) : '[]';
 
         return <<<EOT
     var Ziggy = {
@@ -51,7 +53,8 @@ class CommandRouteGenerator extends Command
         baseUrl: '{$this->baseUrl}',
         baseProtocol: '{$this->baseProtocol}',
         baseDomain: '{$this->baseDomain}',
-        basePort: {$this->basePort}
+        basePort: {$this->basePort},
+        defaultParameters: $defaultParameters
     };
 
     export {

--- a/tests/assets/js/ziggy.js
+++ b/tests/assets/js/ziggy.js
@@ -3,7 +3,8 @@
         baseUrl: 'http://myapp.com/',
         baseProtocol: 'http',
         baseDomain: 'myapp.com',
-        basePort: false
+        basePort: false,
+        defaultParameters: []
     };
 
     export {


### PR DESCRIPTION
Added `defaultParameters` into JS code generated by `CommandRouteGenerator`. This fixes the `Uncaught TypeError: Cannot read property '...' of undefined` when Ziggy is loaded with Laravel Mix and not with the `@routes` directive.