### PR TITLE
Add ability to specify a custom URL in the generator command

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -10,7 +10,7 @@ use Tightenco\Ziggy\RoutePayload;
 
 class CommandRouteGenerator extends Command
 {
-    protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js}';
+    protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js} {--url=/}';
 
     protected $description = 'Generate js file for including in build process';
 
@@ -66,7 +66,7 @@ EOT;
 
     private function prepareDomain()
     {
-        $url = url('/');
+        $url = url($this->option('url'));
         $parsedUrl = parse_url($url);
 
         $this->baseUrl = $url . '/';

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -40,4 +40,19 @@ class CommandRouteGeneratorTest extends TestCase
 
         $this->assertFileEquals('./tests/assets/js/ziggy.js', vfsStream::url('testDir/ziggy.js'));
     }
+
+    /** @test */
+    function file_is_created_with_a_custom_url()
+    {
+        $router = app('router');
+
+        $router->get('/posts/{post}/comments', function () { return ''; })
+            ->name('postComments.index');
+
+        $router->getRoutes()->refreshNameLookups();
+
+        Artisan::call('ziggy:generate', ['path' => vfsStream::url('testDir/ziggy.js'), '--url' => 'http://example.org']);
+
+        $this->assertFileEquals('./tests/assets/js/custom-url.js', vfsStream::url('testDir/ziggy.js'));
+    }
 }

--- a/tests/assets/js/custom-url.js
+++ b/tests/assets/js/custom-url.js
@@ -1,0 +1,12 @@
+    var Ziggy = {
+        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}},
+        baseUrl: 'http://example.org/',
+        baseProtocol: 'http',
+        baseDomain: 'example.org',
+        basePort: false,
+        defaultParameters: []
+    };
+
+    export {
+        Ziggy
+    }


### PR DESCRIPTION
This PR adds an `--url` option to the artisan command that generates the static route files so a user can pass a custom URL to be used by the generator.

This is useful when generating the assets for production locally, so we can specify the production url before pushing a new version.