### PR TITLE
BUGFIX Use current ziggy instance in current method

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -114,7 +114,7 @@ class Router extends String {
         let routeNames = Object.keys(this.ziggy.namedRoutes);
 
         let currentRoute = routeNames.filter(name => {
-            return new Router(name).matchUrl();
+            return new Router(name, undefined, undefined, this.ziggy).matchUrl();
         })[0];
 
         return name ? (name == currentRoute) : currentRoute;

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -5,11 +5,11 @@ let moxios = require('moxios');
 import route from '../../src/js/route.js';
 
 global.Ziggy = {
-    namedRoutes: { 
+    namedRoutes: {
         "translateTeam.user.show": {
             "uri": "{locale}/users/{id}",
             "methods": ["GET", "HEAD"],
-            "domain": "{team}.myapp.dev" 
+            "domain": "{team}.myapp.dev"
         },
         "translateEvents.venues.show": {
             "uri": "{locale}/events/{event}/venues/{venue}",
@@ -115,7 +115,7 @@ describe('route()', function() {
         );
     });
 
-    
+
     it('Should return URL without domain when passing false into absolute param.', function() {
         assert.equal(
             "/posts",
@@ -639,6 +639,41 @@ describe('route()', function() {
         assert.equal(
             'http://notYourAverage.dev/tightenDev/1/packages',
             route('tightenDev.packages.index', { dev: 1 }, true, customZiggy).url()
-        )
+        );
+    });
+
+    it('Should allow route().current() when there is no global Ziggy object', function() {
+        const orgZiggy = global.Ziggy;
+
+        global.Ziggy = undefined;
+
+        global.window = {
+            location: {
+                hostname: "myapp.dev",
+                pathname: "/events/",
+                protocol: ""
+            }
+        };
+
+        const customZiggy = {
+            namedRoutes: {
+                "events.index": {
+                    "uri": "events",
+                    "methods": ["GET", "HEAD"],
+                    "domain": null
+                },
+            },
+            baseUrl: 'http://myapp.dev/',
+            baseProtocol: 'http',
+            baseDomain: 'myapp.dev',
+            basePort: false,
+        };
+
+        assert.equal(
+            'events.index',
+            route(undefined, undefined, undefined, customZiggy).current()
+        );
+
+        global.Ziggy = orgZiggy;
     });
 });


### PR DESCRIPTION
When there is no global Ziggy instance, for example when not useing the blade directive and bundling the lib with webpack, there is not a global Ziggy, so when one calls `route().current()` it fails as this method instantiate a new `Route` instance without passing a Ziggy instance.