### PR TITLE
Only remove null and undefined query params

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -101,7 +101,7 @@ class Router extends String {
         let queryString = '?';
 
         Object.keys(this.queryParams).forEach(function(key, i) {
-            if (this.queryParams[key]) {
+            if (this.queryParams[key] !== undefined && this.queryParams[key] !== null) {
                 queryString = i === 0 ? queryString : queryString + '&';
                 queryString += key + '=' + encodeURIComponent(this.queryParams[key]);
             }


### PR DESCRIPTION
Right now Ziggy is stripping query params with empty strings and zeros (falsey values). Since those can be valid query params, this change updates it to only remove null and undefined values.

Fixes #157 and #141