### PR TITLE
Update blacklist config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To take advantage of basic whitelisting or blacklisting of routes, you will firs
 <?php
 return [
     // 'whitelist' => ['home', 'api.*'],
-    'blacklist' => ['admin.*', 'vulnerabilities.*'],
+    'blacklist' => ['debugbar.*', 'horizon.*', 'admin.*'],
 ];
 ```
 


### PR DESCRIPTION
Hi,

Laravel [debugbar](https://github.com/barryvdh/laravel-debugbar) and Laravel horizon are the most common packages now. They do have their own routes but as an end user we don't use them.
I have to add these two in the `blacklist` in every project.
```php
'blacklist' => ['debugbar.*', 'horizon.*'],
```
Since the package does not come with an physical config file; the example in readme.md is first place to go and copy-past the code to the `ziggy.php` file.

