### PR TITLE
Add middleware to route data

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -10,7 +10,7 @@ use Tightenco\Ziggy\RoutePayload;
 
 class CommandRouteGenerator extends Command
 {
-    protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js} {--url=/}';
+    protected $signature = 'ziggy:generate {path=./resources/assets/js/ziggy.js} {--url=/} {--only-routes}';
 
     protected $description = 'Generate js file for including in build process';
 
@@ -41,9 +41,13 @@ class CommandRouteGenerator extends Command
 
     public function generate($group = false)
     {
-        $this->prepareDomain();
-
         $json = $this->getRoutePayload($group)->toJson();
+        
+        if ($this->option('only-routes')) {
+            return 'export default ' . $json;
+        }
+        
+        $this->prepareDomain();
 
         $defaultParameters = method_exists(app('url'), 'getDefaultParameters') ? json_encode(app('url')->getDefaultParameters()) : '[]';
 

--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -91,8 +91,18 @@ class RoutePayload
                     $this->appendRouteToList($route->getName(), 'whitelist');
                 }
 
-                return collect($route)->only(['uri', 'methods'])
+                $collection = collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain());
+                
+                if ($middleware = config('ziggy.middleware')) {
+                    if ($middleware === true) {
+                        $collection->put('middleware', $route->middleware());
+                    } elseif (is_array($middleware)) {
+                        $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());
+                    }
+                }
+                
+                return $collection;
             });
     }
 

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -33,10 +33,10 @@ class RoutePayloadTest extends TestCase
                ->name('postComments.index');
 
         $this->router->post('/posts', function () { return ''; })
-               ->name('posts.store');
+               ->name('posts.store')->middleware(['auth', 'role:admin']);
 
        $this->router->get('/admin/users', function () { return ''; })
-              ->name('admin.users.index');
+              ->name('admin.users.index')->middleware('role:admin');
 
         $this->router->getRoutes()->refreshNameLookups();
     }
@@ -265,6 +265,108 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+    
+    /** @test */
+    public function retrieves_middleware_if_config_is_set()
+    {
+        app()['config']->set('ziggy', [
+            'middleware' => true
+        ]);
+        
+        $routes = RoutePayload::compile($this->router);
+
+        $expected = [
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+                'middleware' => ['auth', 'role:admin'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => ['role:admin'],
+            ],
+        ];
+
+        $this->assertEquals($expected, $routes->toArray());
+    }
+    
+    /** @test */
+    public function retrieves_only_configured_middleware()
+    {
+        app()['config']->set('ziggy', [
+            'middleware' => ['auth']
+        ]);
+
+        $routes = RoutePayload::compile($this->router);
+
+        $expected = [
+            'posts.index' => [
+                'uri' => 'posts',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'postComments.index' => [
+                'uri' => 'posts/{post}/comments',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+                'middleware' => ['auth'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
             ],
         ];
 


### PR DESCRIPTION
## Use case
I have front-end project with backend proxy which proxies requests to Laravel api with Passport installed. 
I need to know how exactly should I proxy requests based on middleware of laravel routes. 
- for **client** passport middleware I need to pass *client access_token* to api routes
- for **auth:api** middleware I need to pass *completly different access_token* to api routes

With middleware route information from ziggy routes you can distinguish such routes easily.

## Changes
Added support for **middleware** config property for ziggy. 
- if **middleware** is set to true, then all route middleware will be returned. 
- if **middleware** is set to array of middlewares, then only given middleware will be returned.
- if no **middleware** is set then no changes are introduces, default behavior stays the same.