### PR TITLE
Moving JavaScript rendering to Blade for CSP support

### DIFF
--- a/resources/views/javascript.blade.php
+++ b/resources/views/javascript.blade.php
@@ -1,0 +1,12 @@
+<script type="text/javascript">
+    var Ziggy = {
+        namedRoutes: {!! $namedRoutes   !!},
+        baseUrl: '{{ $baseUrl }}',
+        baseProtocol: '{{ $baseProtocol }}',
+        baseDomain: '{{ $baseDomain }}',
+        basePort: {{ $basePort }},
+        defaultParameters: {{ $defaultParameters  }}
+    };
+
+    {!!  $routeFunction   !!}
+</script>

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -41,20 +41,15 @@ class BladeRouteGenerator
 
         static::$generated = true;
 
-        return <<<EOT
-<script type="text/javascript">
-    var Ziggy = {
-        namedRoutes: $json,
-        baseUrl: '{$this->baseUrl}',
-        baseProtocol: '{$this->baseProtocol}',
-        baseDomain: '{$this->baseDomain}',
-        basePort: {$this->basePort},
-        defaultParameters: $defaultParameters
-    };
-
-    $routeFunction
-</script>
-EOT;
+        return view('ziggy::javascript', [
+            'namedRoutes' => $json,
+            'baseUrl' => $this->baseUrl,
+            'baseProtocol' => $this->baseProtocol,
+            'baseDomain' => $this->baseDomain,
+            'basePort' => $this->basePort,
+            'defaultParameters' => $defaultParameters,
+            'routeFunction' => $routeFunction,
+        ])->render();
     }
 
     private function generateMergeJavascript($json)

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -27,5 +27,7 @@ class ZiggyServiceProvider extends ServiceProvider
                 CommandRouteGenerator::class,
             ]);
         }
+
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'ziggy');
     }
 }


### PR DESCRIPTION
I am trying to implement CSP in my project which relies heavily on this excellent page. I have looked at issue #181 and got the idea of this quick solution. By moving the JavaScript rendering to a Blade view it's possible for an app to [override the package view using Blade's standard mechanisms](https://laravel.com/docs/5.8/packages#views) by putting a view in `/resources/views/vendors/`

This solution will not:
- add any complexity to BladeRouteGenerator
- break existing behavior 
- adding a second (and hacky) parameter to the Blade directive.

Example: This makes it easy, for example, to integrate Spatie's Laravel CSP-package by simple overriding this view and adding the `csp_nonce`-helper and override Ziggy's default Blade view.

```
// <my-project>/resources/views/vendors/ziggy/javascript.blade.php

<script type="text/javascript" nonce="{{ csp_nonce() }}">
    var Ziggy = {
        namedRoutes: {!! $namedRoutes   !!},
        baseUrl: '{{ $baseUrl }}',
        ...
```
What do you think, could this work?