### PR TITLE
Check for falsy value as well, fixes #186

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -69,7 +69,7 @@ class Router extends String {
                 }
 
                 paramsArrayKey++;
-                if (typeof tags[key] !== 'undefined') {
+                if (tags[key] && typeof tags[key] !== 'undefined') {
                     delete this.queryParams[key];
                     return tags[key].id || encodeURIComponent(tags[key]);
                 }


### PR DESCRIPTION
We were just checking for undefined values, while we should also check for `false`, `null` values as well.
fixes #186 