### PR TITLE
Allow the baseUrl to be overridden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - nvm use stable
   - npm ci
 script:
-  - phpunit
+  - vendor/bin/phpunit
   - npm run build
   - npm test
 cache:

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.6",
-        "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^7.0"
+        "mikey179/vfsstream": "^1.6"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tightenco/ziggy",
+    "name": "my/ziggy",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "require": {
         "laravel/framework": "~5.4"
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.6",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpunit": "^7.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "my/ziggy",
+    "name": "tightenco/ziggy",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "require": {
         "laravel/framework": "~5.4"

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -88,8 +88,7 @@ EOT;
 
     private function prepareDomain()
     {
-        $url = config('ziggy.base_url', null) ?? url('/');
-        dump([ $url ]);
+        $url = config('ziggy.base_url', url('/'));
         $parsedUrl = parse_url($url);
 
         $this->baseUrl = $url . '/';

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -88,7 +88,8 @@ EOT;
 
     private function prepareDomain()
     {
-        $url = url('/');
+        $url = config('ziggy.base_url', null) ?? url('/');
+        dump([ $url ]);
         $parsedUrl = parse_url($url);
 
         $this->baseUrl = $url . '/';

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -97,4 +97,25 @@ class BladeRouteGeneratorTest extends TestCase
         $this->assertArrayHasKey('posts.store', $array);
         $this->assertArrayHasKey('postComments.index', $array);
     }
+
+    /** @test */
+    function generator_uses_provided_config_for_baseurl()
+    {
+        config([ 'ziggy.base_url' => '/new-base' ]);
+
+        $router = app('router');
+
+        // Named. Should end up in JSON
+        $router->get('/posts', function () { return ''; })
+            ->name('posts.index');
+        $router->get('/' . config('ziggy.base_url') . '/posts', function () { return ''; })
+            ->name('base.posts.index');
+
+        $router->getRoutes()->refreshNameLookups();
+
+        $generator = (new BladeRouteGenerator($router));
+
+        $result = $generator->generate();
+        $this->assertRegexp("|'/new-base/'|", $result);
+    }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -116,6 +116,6 @@ class BladeRouteGeneratorTest extends TestCase
         $generator = (new BladeRouteGenerator($router));
 
         $result = $generator->generate();
-        $this->assertRegexp("|'/new-base/'|", $result);
+        $this->assertRegexp('"new-base\\/', $result);
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -17,7 +17,7 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $generator = app(BladeRouteGenerator::class);
 
-        $this->assertContains("namedRoutes: []", $generator->generate());
+        $this->assertStringContainsString("namedRoutes: []", $generator->generate());
     }
 
     /** @test */
@@ -116,6 +116,6 @@ class BladeRouteGeneratorTest extends TestCase
         $generator = (new BladeRouteGenerator($router));
 
         $result = $generator->generate();
-        $this->assertRegexp('"new-base\\/', $result);
+        $this->assertStringContainsString('"base.posts.index":{"uri":"new-base', $generator->generate());
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -116,6 +116,6 @@ class BladeRouteGeneratorTest extends TestCase
         $generator = (new BladeRouteGenerator($router));
 
         $result = $generator->generate();
-        $this->assertRegexp('"new-base\\/', $result);
+        $this->assertContains('"new-base\/', $result);
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -17,7 +17,7 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $generator = app(BladeRouteGenerator::class);
 
-        $this->assertContains("namedRoutes: []", $generator->generate());
+        $this->assertStringContainsString("namedRoutes: []", $generator->generate());
     }
 
     /** @test */
@@ -116,6 +116,6 @@ class BladeRouteGeneratorTest extends TestCase
         $generator = (new BladeRouteGenerator($router));
 
         $result = $generator->generate();
-        $this->assertContains('"new-base\/', $result);
+        $this->assertStringContainsString('"base.posts.index":{"uri":"new-base', $generator->generate());
     }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -17,7 +17,7 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $generator = app(BladeRouteGenerator::class);
 
-        $this->assertStringContainsString("namedRoutes: []", $generator->generate());
+        $this->assertContains("namedRoutes: []", $generator->generate());
     }
 
     /** @test */
@@ -116,6 +116,6 @@ class BladeRouteGeneratorTest extends TestCase
         $generator = (new BladeRouteGenerator($router));
 
         $result = $generator->generate();
-        $this->assertStringContainsString('"base.posts.index":{"uri":"new-base', $generator->generate());
+        $this->assertRegexp('"new-base\\/', $result);
     }
 }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -10,7 +10,7 @@ use org\bovigo\vfs\vfsStreamWrapper;
 
 class CommandRouteGeneratorTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -15,7 +15,7 @@ class RoutePayloadTest extends TestCase
 {
     protected $router;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -270,14 +270,14 @@ class RoutePayloadTest extends TestCase
 
         $this->assertEquals($expected, $routes->toArray());
     }
-    
+
     /** @test */
     public function retrieves_middleware_if_config_is_set()
     {
         app()['config']->set('ziggy', [
             'middleware' => true
         ]);
-        
+
         $routes = RoutePayload::compile($this->router);
 
         $expected = [
@@ -321,7 +321,7 @@ class RoutePayloadTest extends TestCase
 
         $this->assertEquals($expected, $routes->toArray());
     }
-    
+
     /** @test */
     public function retrieves_only_configured_middleware()
     {


### PR DESCRIPTION
We're working on setting up multi-tenant (which actually includes sub-tenants, where the sub-tenant information is in the url path). We want to ensure that paths generated by ziggy will include the sub-tenant information, therefore we want to allow the baseUrl value to be easily customized, with a fallback to `/` when not provided.

### Expected Behavior
Allows for a new configuration option `ziggy.base_url` that contains a path instead of `/`.

### Current Behavior
Currently, all baseUrl's are assumed to be `/`