### PR TITLE
updates string and array helpers

### DIFF
--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -2,6 +2,8 @@
 
 namespace Tightenco\Ziggy;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Routing\Router;
 
 class RoutePayload
@@ -54,7 +56,7 @@ class RoutePayload
         else if(config()->has("ziggy.groups.{$group}")) {
             return $this->filter(config("ziggy.groups.{$group}"), true);
         }
-        
+
         return $this->routes;
     }
 
@@ -72,7 +74,7 @@ class RoutePayload
     {
         return $this->routes->filter(function ($route, $name) use ($filters, $include) {
             foreach ($filters as $filter) {
-                if (str_is($filter, $name)) {
+                if (Str::is($filter, $name   )) {
                     return $include;
                 }
             }
@@ -111,6 +113,6 @@ class RoutePayload
     protected function isListedAs($route, $list)
     {
         return (isset($route->listedAs) && $route->listedAs === $list)
-            || array_get($route->getAction(), 'listed_as', null) === $list;
+            || Arr::get($route->getAction(), 'listed_as', null) === $list;
     }
 }


### PR DESCRIPTION
String and array helpers have been removed in 5.9 I'm playing around with that branch and got bit trying to run `php artisan ziggy:generate` so I fixed it and I'm submitting the PR. 

https://laravel-news.com/laravel-5-8-deprecates-string-and-array-helpers

