### PR TITLE
Updates package to be compatible with Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tightenco/ziggy",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "require": {
-        "laravel/framework": ">=5.4@dev"
+        "laravel/framework": ">=5.4@dev|6.0.*@dev"
     },
     "license": "MIT",
     "authors": [
@@ -26,7 +26,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6",
+        "orchestra/testbench": "~3.6|~3.9@dev",
         "mikey179/vfsstream": "^1.6"
     },
     "extra": {
@@ -35,5 +35,6 @@
                 "Tightenco\\Ziggy\\ZiggyServiceProvider"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Currently it seems Ziggy can't be installed with Laravel 6. Everything appears to work with the following changes to the composer.json file.