### PR TITLE
Trim trailing slashes on url generation

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -8,10 +8,8 @@ class Router extends String {
         this.name = name;
         this.absolute = absolute;
         this.ziggy = customZiggy ? customZiggy : Ziggy;
-        (this.template = this.name
-            ? new UrlBuilder(name, absolute, this.ziggy).construct()
-            : ''),
-            (this.urlParams = this.normalizeParams(params));
+        this.template = this.name ? new UrlBuilder(name, absolute, this.ziggy).construct() : '';
+        this.urlParams = this.normalizeParams(params);
         this.queryParams = {};
         this.hydrated = '';
     }

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -8,7 +8,8 @@ class Router extends String {
         this.name = name;
         this.absolute = absolute;
         this.ziggy = customZiggy ? customZiggy : Ziggy;
-        this.template = this.name ? new UrlBuilder(name, absolute, this.ziggy).construct() : '';
+        this.urlBuilder = this.name ? new UrlBuilder(name, absolute, this.ziggy) : null;
+        this.template = this.urlBuilder ? this.urlBuilder.construct() : '';
         this.urlParams = this.normalizeParams(params);
         this.queryParams = {};
         this.hydrated = '';
@@ -49,7 +50,7 @@ class Router extends String {
     hydrateUrl() {
         if (this.hydrated) return this.hydrated;
 
-        return (this.hydrated = this.template.replace(
+        let hydrated = this.template.replace(
             /{([^}]+)}/gi,
             (tag, i) => {
                 let keyName = this.trimParam(tag),
@@ -97,7 +98,15 @@ class Router extends String {
 
                 return encodeURIComponent(tagValue);
             }
-        ));
+        );
+
+        if (this.urlBuilder != null && this.urlBuilder.path !== '') {
+          hydrated = hydrated.replace(/\/+$/, '');
+        }
+
+        this.hydrated = hydrated;
+
+        return this.hydrated;
     }
 
     matchUrl() {

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -413,7 +413,7 @@ describe('route()', function() {
     it('Should skip the optional parameter `slug`', function() {
         assert.equal(
             route('optional', { id: 123 }),
-            'http://myapp.dev/optional/123/'
+            'http://myapp.dev/optional/123'
         );
     });
 


### PR DESCRIPTION
This should resolve #174. Also matches [Laravel's behavior](https://github.com/laravel/framework/blob/75924e923096e18c2a414ee0e17c0edc13cd8bb8/src/Illuminate/Routing/RouteUrlGenerator.php#L208) AFAICT.