### PR TITLE
Add note about using `url()` helper with Axios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ return axios.get(route('posts.show', post))
         return response.data;
     });
 ```
+
+_Note: If you are using Axios and making requests which require CSRF verification, use the `url()` method on the route (documented below). This will ensure that the `X-XSRF-TOKEN` header is sent with the request._
+
 ### Default Values
 See Laravel [documentation](https://laravel.com/docs/5.5/urls#default-values)
 


### PR DESCRIPTION
I know you probably don't want to document behaviors for 3rd party libraries, but Axios seems to be the most likely choice for many devs and is already mentioned in the docs. I have a feeling I am not / will not be the only user bit by this issue.

Basically, passing the Ziggy route directly will cause Axios to think the request is cross-domain, and it will therefore not send the CSRF header unless you specify an additional option intended for cross-domain requests.

Here is the relevant Axios code:

https://github.com/axios/axios/blob/6284abfa0693c983e9378b2d074c095262aac7bd/lib/helpers/isURLSameOrigin.js#L59