### PR TITLE
Utilize afterResolving for Laravel 6.10 and up

### DIFF
--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -18,14 +18,25 @@ class ZiggyServiceProvider extends ServiceProvider
             return Macro::whitelist($this, $group);
         });
 
-        $this->app['blade.compiler']->directive('routes', function ($group) {
-            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
-        });
+        if ($this->app->resolved('blade.compiler')) {
+            $this->registerDirective($this->app['blade.compiler']);
+        } else {
+            $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+                $this->registerDirective($bladeCompiler);
+            });
+        }
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 CommandRouteGenerator::class,
             ]);
         }
+    }
+
+    protected function registerDirective(BladeCompiler $bladeCompiler)
+    {
+        $bladeCompiler->directive('routes', function ($group) {
+            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+        });
     }
 }


### PR DESCRIPTION
A fix was implemented in Laravel 6.10 making the framework no longer resolve the blade compiler on start up (laravel/framework#31009).

The following change utilizes this improvement by not calling the compiler directly if it's not yet been resolved.