### PR TITLE
Fix webpack path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ mix.webpackConfig({
     resolve: {
         alias: {
             ...
-            ziggy: path.resolve('vendor/tightenco/ziggy/dist/js/route.js'),
+            ziggy: path.resolve('vendor/tightenco/ziggy/src/js/route.js'),
         },
     },
 })


### PR DESCRIPTION
Using
```
 ziggy: path.resolve('vendor/tightenco/ziggy/dist/js/route.js'),
```
in webpack config results in error messages containing:
```
"export 'default' (imported as '_route') was not found in 'ziggy'
```

This can be solved by using the source file instead of the already compiled one
```
ziggy: path.resolve('vendor/tightenco/ziggy/src/js/route.js'),
```