### PR TITLE
next.js/ssr compatibility

### DIFF
--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -60,7 +60,7 @@ class CommandRouteGenerator extends Command
         defaultParameters: $defaultParameters
     };
 
-    if (window && typeof window.Ziggy !== 'undefined') {
+    if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
         for (var name in window.Ziggy.namedRoutes) {
             Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
         }

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -60,7 +60,7 @@ class CommandRouteGenerator extends Command
         defaultParameters: $defaultParameters
     };
 
-    if (typeof window.Ziggy !== 'undefined') {
+    if (window && typeof window.Ziggy !== 'undefined') {
         for (var name in window.Ziggy.namedRoutes) {
             Ziggy.namedRoutes[name] = window.Ziggy.namedRoutes[name];
         }


### PR DESCRIPTION
When using Ziggy in React SSR SPAs, the `window` variable is not available. See [here](https://github.com/zeit/next.js/issues/6080#issuecomment-455231686) for a discussion.

This PR fixes that check so SSR errors are not produced.