### PR TITLE
npm package compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "module": "src/js/route.js",
     "main": "dist/js/route.min.js",
     "browser": "dist/js/route.min.js",
+    "files": [
+        "src/js",
+        "dist"
+    ],
     "directories": {
         "test": "tests/js"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.9.1",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "module": "src/js/route.js",
-    "main": "dist/js/route.min.js",
+    "main": "src/js/route.js",
     "browser": "dist/js/route.min.js",
     "files": [
         "src/js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "laravel-ziggy",
-    "version": "0.5.0",
+    "name": "ziggy-js",
+    "version": "0.9.1",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "module": "src/js/route.js",
     "main": "dist/js/route.min.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "build": "NODE_ENV=production webpack --progress",
         "build:watch": "npm run build -- --watch",
         "test": "NODE_ENV=test mocha-webpack 'tests/js/**/*.js'",
-        "test:watch": "npm run test -- --watch"
+        "test:watch": "npm run test -- --watch",
+        "prepublishOnly": "npm run build"
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-    "name": "ziggy",
+    "name": "laravel-ziggy",
     "version": "0.5.0",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
     "main": "src/js/route.js",
+    "browser": "dist/js/route.min.js",
     "directories": {
         "test": "tests/js"
     },
@@ -31,12 +32,13 @@
         "mocha": "^6.2.0",
         "mocha-webpack": "^2.0.0-beta.0",
         "moxios": "^0.4.0",
-        "qs": "^6.8.0",
         "unminified-webpack-plugin": "^2.0.0",
         "webpack": "^4.39.3",
         "webpack-cli": "^3.3.7"
     },
-    "dependencies": {},
+    "dependencies": {
+        "qs": "^6.8.0"
+    },
     "engines": {
         "node": ">= 8.9"
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "name": "laravel-ziggy",
     "version": "0.5.0",
     "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
-    "main": "src/js/route.js",
+    "module": "src/js/route.js",
+    "main": "dist/js/route.min.js",
     "browser": "dist/js/route.min.js",
     "directories": {
         "test": "tests/js"


### PR DESCRIPTION
This PR proposes a few `package.json` changes for npm compatibility.

1. Rename to `laravel-ziggy` since the [ziggy](https://www.npmjs.com/package/ziggy) name is already taken on npm.
2. Hoist `qs` out of `devDependencies`, because (see 3 below)...
3. Modern bundlers (rollup, webpack, parcel) will look for a `module` directive as an es6 source, and the [package.json spec](https://docs.npmjs.com/files/package.json#browser) advises to have a `browser` entry point as well.
4. Add a `prepublishOnly` hook to build scripts right before `npm publish`
5. Add a `files` directive to publish only necessary files to npm's registry

If this PR is accepted, please publish to npm (see #277)