### PR TITLE
Fix handling of null optional parameter

### DIFF
--- a/src/js/route.js
+++ b/src/js/route.js
@@ -79,9 +79,9 @@ class Router extends String {
                     delete this.urlParams[keyName];
                 }
 
-                // The type of the value is undefined; is this param
+                // The value is null or defined; is this param
                 // optional or not
-                if (typeof tagValue === 'undefined') {
+                if (tagValue == null) {
                     if (tag.indexOf('?') === -1) {
                         throw new Error(
                             "Ziggy Error: '" +

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -432,6 +432,13 @@ describe('route()', function() {
         );
     });
 
+    it('Should skip the optional parameter `slug` when null', function() {
+        assert.equal(
+            route('optional', { id: 123, slug: null }),
+            'http://myapp.dev/optional/123'
+        );
+    });
+
     it('Should accept the optional parameter `slug`', function() {
         assert.equal(
             route('optional', { id: 123, slug: 'news' }),


### PR DESCRIPTION
This will match current laravel behavior of not throwing error when passed null for optional parameter.