### PR TITLE
Set up GitHub Actions workflow to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up NPM
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm --no-git-tag-version version $(git describe --tags) --allow-same-version
+          npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm ci
+          npm install
           npm --no-git-tag-version version $(git describe --tags) --allow-same-version
           npm publish --access public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   pull_request:


### PR DESCRIPTION
This PR adds a second GitHub Actions workflow to automatically publish Ziggy to npm every time a new release is created in this repo. Depends on #276.

The `Set up NPM` step creates an `.npmrc` file on the runner and configures it to point to the main npm registry and accept the auth token that we pass in the next step.

This line:

```bash
npm --no-git-tag-version version $(git describe --tags) --allow-same-version
```

updates the version in `package.json` and `package-lock.json` to match the most recent tag in this repo, without creating a new tag or commit in the process. If we were clever enough to already do this ourselves, it won't do anything.