### PR TITLE
Allow to set nonce on blade directive

### DIFF
--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -27,12 +27,13 @@ class BladeRouteGenerator
         return RoutePayload::compile($this->router, $group);
     }
 
-    public function generate($group = false)
+    public function generate($group = false, $nonce=false)
     {
         $json = $this->getRoutePayload($group)->toJson();
+        $nonce = $nonce?" nonce='$nonce'":'';
 
         if (static::$generated) {
-            return $this->generateMergeJavascript($json);
+            return $this->generateMergeJavascript($json, $nonce);
         }
 
         $this->prepareDomain();
@@ -44,7 +45,7 @@ class BladeRouteGenerator
         static::$generated = true;
 
         return <<<EOT
-<script type="text/javascript">
+<script type="text/javascript"{$nonce}>
     var Ziggy = {
         namedRoutes: $json,
         baseUrl: '{$this->baseUrl}',
@@ -59,10 +60,10 @@ class BladeRouteGenerator
 EOT;
     }
 
-    private function generateMergeJavascript($json)
+    private function generateMergeJavascript($json, $nonce)
     {
         return <<<EOT
-<script type="text/javascript">
+<script type="text/javascript"{$nonce}>
     (function() {
         var routes = $json;
 

--- a/src/BladeRouteGenerator.php
+++ b/src/BladeRouteGenerator.php
@@ -8,7 +8,7 @@ use function array_key_exists;
 class BladeRouteGenerator
 {
     public static $generated;
-    
+
     public $routePayload;
 
     private $baseDomain;
@@ -27,10 +27,10 @@ class BladeRouteGenerator
         return RoutePayload::compile($this->router, $group);
     }
 
-    public function generate($group = false, $nonce=false)
+    public function generate($group = false, $nonce = false)
     {
         $json = $this->getRoutePayload($group)->toJson();
-        $nonce = $nonce?" nonce='$nonce'":'';
+        $nonce = $nonce ? ' nonce="' . $nonce . '"' : '';
 
         if (static::$generated) {
             return $this->generateMergeJavascript($json, $nonce);

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -106,4 +106,15 @@ class BladeRouteGeneratorTest extends TestCase
         $this->assertArrayHasKey('posts.store', $array);
         $this->assertArrayHasKey('postComments.index', $array);
     }
+
+    /** @test */
+    function generator_can_set_csp_nonce()
+    {
+        $generator = app(BladeRouteGenerator::class);
+
+        $this->assertStringContainsString(
+            '<script type="text/javascript" nonce="supercalifragilisticexpialidocious">',
+            $generator->generate(false, 'supercalifragilisticexpialidocious')
+        );
+    }
 }


### PR DESCRIPTION
If you need to have a restrictive content security policy that disallows unsafe inline JavaScript you need to either use a nonce or a hash of the script content. This PR allows to use a nonce with the Ziggy blade directive.
```
@routes(false, 'example-nonce')
@routes(false, csp_nonce()) // With laravel-csp
```