### PR TITLE
Fix assets being generated in current working directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
-        "mikey179/vfsstream": "^1.6"
+        "orchestra/testbench": "^5.0"
     },
     "extra": {
         "laravel": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>

--- a/src/CommandRouteGenerator.php
+++ b/src/CommandRouteGenerator.php
@@ -37,7 +37,7 @@ class CommandRouteGenerator extends Command
 
         $this->makeDirectory($path);
 
-        $this->files->put($path, $generatedRoutes);
+        $this->files->put(base_path($path), $generatedRoutes);
         
         $this->info('File generated!');
     }
@@ -91,8 +91,8 @@ EOT;
 
     protected function makeDirectory($path)
     {
-        if (! $this->files->isDirectory(dirname($path))) {
-            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        if (! $this->files->isDirectory(dirname(base_path($path)))) {
+            $this->files->makeDirectory(dirname(base_path($path)), 0777, true, true);
         }
         return $path;
     }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -3,9 +3,6 @@
 namespace Tests\Unit;
 
 use Illuminate\Support\Facades\Artisan;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
-use org\bovigo\vfs\vfsStreamWrapper;
 use Tightenco\Tests\TestCase;
 
 class CommandRouteGeneratorTest extends TestCase

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -8,7 +8,7 @@ use Tightenco\Tests\TestCase;
 class CommandRouteGeneratorTest extends TestCase
 {
     /** @test */
-    public function file_is_created_when_ziggy_generate_is_called()
+    function file_is_created_when_ziggy_generate_is_called()
     {
         Artisan::call('ziggy:generate');
 
@@ -16,7 +16,7 @@ class CommandRouteGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function file_is_created_when_ziggy_generate_is_called_from_outside_project_root()
+    function file_is_created_when_ziggy_generate_is_called_from_outside_project_root()
     {
         chdir('..');
         $this->assertNotEquals(base_path(), getcwd());
@@ -27,7 +27,7 @@ class CommandRouteGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function file_is_created_with_the_expected_structure_when_named_routes_exist()
+    function file_is_created_with_the_expected_structure_when_named_routes_exist()
     {
         $router = app('router');
 
@@ -44,7 +44,7 @@ class CommandRouteGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function file_is_created_with_a_custom_url()
+    function file_is_created_with_a_custom_url()
     {
         $router = app('router');
 
@@ -61,7 +61,7 @@ class CommandRouteGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function file_is_created_with_the_expected_group()
+    function file_is_created_with_the_expected_group()
     {
         app()['config']->set('ziggy', [
             'blacklist' => ['admin.*'],

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tightenco\Tests\Unit;
 
 use Illuminate\Support\Facades\Artisan;
 use Tightenco\Tests\TestCase;


### PR DESCRIPTION
This PR uses Laravel's `base_path()` helper to ensure that the `ziggy:generate` command always outputs assets to the correct location, even when run somewhere other than the project root.

I added a test to ensure this behaves correctly. In order for the test to work, and because Ziggy will now always use an absolute file path internally, I updated the tests to use the real filesystem instead of a virtual one. The files are generated inside Testbench's dummy Laravel app, at `vendor/orchestra/testbench-core/laravel/...`, and the new `tearDown()` method ensures they're deleted between tests. The `vfsstream` dependency was no longer needed, so I removed it.

Fixes #282.