### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), and the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+Breaking changes marked with ⚠️.
+
+**Added**
+
+- Document the `check()` method ([#294](https://github.com/tightenco/ziggy/pull/294)) and how to install and use Ziggy via `npm` and over a CDN ([#299](https://github.com/tightenco/ziggy/pull/299))
+
+**Changed**
+
+<!-- - ⚠️ Update the default URL protocol from `http` to `https` -->
+- ⚠️ Update `ziggy:generate` output path for Laravel 5.7+ `resources` directory structure, thanks [@Somethingideally](https://github.com/Somethingideally)! ([#269](https://github.com/tightenco/ziggy/pull/269))
+
+**Fixed**
+
+- Fix automatic `id` parameter detection by also excluding routes with an _optional_ `id` parameter (`{id?}`), thanks [@Livijn](https://github.com/Livijn)! ([#263](https://github.com/tightenco/ziggy/pull/263))
+- Fix port not being added to URL for routes with subdomains ([#293](https://github.com/tightenco/ziggy/pull/293))
+
+## [0.9.4] - 2020-06-05
+
+**Fixed**
+
+- Fix escaping of `.` characters in the `current()` method, thanks [@davejamesmiller](https://github.com/davejamesmiller)! ([#296](https://github.com/tightenco/ziggy/pull/296))
+
+## [0.9.3] - 2020-05-08
+
+**Added**
+
+- Add support for passing a CSP `nonce` attribute to the `@routes` Blade directive to be set on the script tag, thanks [@tminich](https://github.com/tminich)! (#287)
+
+**Changed**
+
+- Improve support for using Ziggy with server-side rendering, thanks [@emielmolenaar](https://github.com/emielmolenaar)! ([#260](https://github.com/tightenco/ziggy/pull/260))
+- Avoid resolving the Blade compiler unless necessary, thanks [@axlon](https://github.com/axlon)! ([#267](https://github.com/tightenco/ziggy/pull/267))
+- Use `dist/js/route.js` as the npm package's main target, thanks [@ankurk91](https://github.com/ankurk91) and [@benallfree](https://github.com/benallfree)! ([#276](https://github.com/tightenco/ziggy/pull/276))
+- Readme and quality-of-life improvements ([#289](https://github.com/tightenco/ziggy/pull/289))
+
+**Fixed**
+
+- Ensure Ziggy's assets are always generated in the correct location ([#290](https://github.com/tightenco/ziggy/pull/290))
+
+---
+
+For previous changes see the [Releases](https://github.com/tightenco/ziggy/releases) page.
+
+[Unreleased]: https://github.com/tightenco/ziggy/compare/0.9.4...HEAD
+[0.9.4]: https://github.com/tightenco/ziggy/compare/0.9.3...0.9.4
+[0.9.3]: https://github.com/tightenco/ziggy/compare/v0.9.2...0.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-Breaking changes marked with ⚠️.
+Breaking changes are marked with ⚠️.
 
 **Added**
 
@@ -14,7 +14,6 @@ Breaking changes marked with ⚠️.
 
 **Changed**
 
-<!-- - ⚠️ Update the default URL protocol from `http` to `https` -->
 - ⚠️ Update `ziggy:generate` output path for Laravel 5.7+ `resources` directory structure, thanks [@Somethingideally](https://github.com/Somethingideally)! ([#269](https://github.com/tightenco/ziggy/pull/269))
 
 **Fixed**


### PR DESCRIPTION
This PR adds a changelog at `CHANGELOG.md` in the project root. Right now it's more or less the same as this repo's Releases page, but it's useful to have everything in one file in a standard, portable format.

It's also nice for keeping a list of upcoming but unreleased changes, particularly right now as we near `1.0`, since there are quite a few (and more coming).