### PR TITLE
Add support for custom scoped route model bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes are marked with ⚠️.
 **Added**
 
 - Document the `check()` method ([#294](https://github.com/tightenco/ziggy/pull/294)) and how to install and use Ziggy via `npm` and over a CDN ([#299](https://github.com/tightenco/ziggy/pull/299))
+- Add support for [custom scoped route model bindings](https://laravel.com/docs/7.x/routing#implicit-binding), e.g. `/users/{user}/posts/{post:slug}` ([#307](https://github.com/tightenco/ziggy/pull/307))
 
 **Changed**
 

--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -95,6 +95,7 @@ class RoutePayload
 
                 return collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain())
+                    ->put('bindings', $route->bindingFields())
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
                         if (is_array($middleware)) {
                             return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());

--- a/src/RoutePayload.php
+++ b/src/RoutePayload.php
@@ -95,7 +95,9 @@ class RoutePayload
 
                 return collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain())
-                    ->put('bindings', $route->bindingFields())
+                    ->when(method_exists($route, 'bindingFields'), function ($collection) use ($route) {
+                        return $collection->put('bindings', $route->bindingFields());
+                    })
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
                         if (is_array($middleware)) {
                             return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());

--- a/src/js/route.js
+++ b/src/js/route.js
@@ -67,13 +67,22 @@ class Router extends String {
                     delete this.urlParams[keyName];
                 }
 
+                // The block above is what requires us to assign tagValue below
+                // instead of returning - if multiple *objects* are passed as
+                // params, numericParamIndices will be true and each object will
+                // be assigned above, which means !tagValue will evaluate to
+                // false, skipping the block below.
+
                 // If a value wasn't provided for this named parameter explicitly,
                 // but the object that was passed contains an ID, that object
                 // was probably a model, so we use the ID.
-                // Note that we are not explicitly ensuring here that the template
-                // doesn't have an ID param (`this.template.indexOf('{id}') == -1`)
-                // because we don't need to - if it does, we won't get this far.
-                if (!tagValue && !this.urlParams[keyName] && this.urlParams['id']) {
+
+                let bindingKey = this.ziggy.namedRoutes[this.name]?.bindings?.[keyName];
+
+                if (bindingKey && !this.urlParams[keyName] && this.urlParams[bindingKey]) {
+                    tagValue = this.urlParams[bindingKey];
+                    delete this.urlParams[bindingKey];
+                } else if (!tagValue && !this.urlParams[keyName] && this.urlParams['id']) {
                     tagValue = this.urlParams['id']
                     delete this.urlParams['id'];
                 }
@@ -97,6 +106,8 @@ class Router extends String {
                 // If an object was passed and has an id, return it
                 if (tagValue.id) {
                     return encodeURIComponent(tagValue.id);
+                } else if (tagValue[bindingKey]) {
+                    return encodeURIComponent(tagValue[bindingKey])
                 }
 
                 return encodeURIComponent(tagValue);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,13 @@ class TestCase extends OrchestraTestCase
         ];
     }
 
+    protected function laravelVersion(int $v = null)
+    {
+        $version = (int) head(explode('.', app()->version()));
+
+        return isset($v) ? $version >= $v : $version;
+    }
+
     protected function assertJsonContains(array $haystack, array $needle)
     {
         $actual = json_encode(Arr::sortRecursive(

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -30,14 +30,19 @@ class BladeRouteGeneratorTest extends TestCase
 
         $generator = (new BladeRouteGenerator($router));
 
-        $this->assertEquals([
+        $expected = [
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
-        ], $generator->getRoutePayload()->toArray());
+        ];
+
+        if ($this->laravelVersion(7)) {
+            $expected['postComments.index']['bindings'] = [];
+        }
+
+        $this->assertEquals($expected, $generator->getRoutePayload()->toArray());
     }
 
     /** @test */
@@ -57,14 +62,19 @@ class BladeRouteGeneratorTest extends TestCase
 
         $generator = (new BladeRouteGenerator($router));
 
-        $this->assertEquals([
+        $expected = [
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
-                'bindings' => [],
             ],
-        ], $generator->getRoutePayload()->toArray());
+        ];
+
+        if ($this->laravelVersion(7)) {
+            $expected['postComments.index']['bindings'] = [];
+        }
+
+        $this->assertEquals($expected, $generator->getRoutePayload()->toArray());
     }
 
     /** @test */

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -35,6 +35,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ], $generator->getRoutePayload()->toArray());
     }
@@ -61,6 +62,7 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
+                'bindings' => [],
             ],
         ], $generator->getRoutePayload()->toArray());
     }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -44,7 +44,7 @@ class CommandRouteGeneratorTest extends TestCase
             $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
         } else {
             $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/ziggy.js')),
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/ziggy.js')),
                 file_get_contents(base_path('resources/js/ziggy.js'))
             );
         }
@@ -68,7 +68,7 @@ class CommandRouteGeneratorTest extends TestCase
             $this->assertFileEquals('./tests/fixtures/custom-url.js', base_path('resources/js/ziggy.js'));
         } else {
             $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/custom-url.js')),
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/custom-url.js')),
                 file_get_contents(base_path('resources/js/ziggy.js'))
             );
         }
@@ -105,7 +105,7 @@ class CommandRouteGeneratorTest extends TestCase
             $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
         } else {
             $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/ziggy.js')),
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/ziggy.js')),
                 file_get_contents(base_path('resources/js/ziggy.js'))
             );
         }
@@ -116,7 +116,7 @@ class CommandRouteGeneratorTest extends TestCase
             $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
         } else {
             $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/admin.js')),
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/admin.js')),
                 file_get_contents(base_path('resources/js/admin.js'))
             );
         }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -40,7 +40,14 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate');
 
-        $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
+        if ($this->laravelVersion(7)) {
+            $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
+        } else {
+            $this->assertSame(
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/ziggy.js')),
+                file_get_contents(base_path('resources/js/ziggy.js'))
+            );
+        }
     }
 
     /** @test */
@@ -57,7 +64,14 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate', ['--url' => 'http://example.org']);
 
-        $this->assertFileEquals('./tests/fixtures/custom-url.js', base_path('resources/js/ziggy.js'));
+        if ($this->laravelVersion(7)) {
+            $this->assertFileEquals('./tests/fixtures/custom-url.js', base_path('resources/js/ziggy.js'));
+        } else {
+            $this->assertSame(
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/custom-url.js')),
+                file_get_contents(base_path('resources/js/ziggy.js'))
+            );
+        }
     }
 
     /** @test */
@@ -87,11 +101,25 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate');
 
-        $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
+        if ($this->laravelVersion(7)) {
+            $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
+        } else {
+            $this->assertSame(
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/ziggy.js')),
+                file_get_contents(base_path('resources/js/ziggy.js'))
+            );
+        }
 
         Artisan::call('ziggy:generate', ['path' => 'resources/js/admin.js', '--group' => 'admin']);
 
-        $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
+        if ($this->laravelVersion(7)) {
+            $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
+        } else {
+            $this->assertSame(
+                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/tests/fixtures/admin.js')),
+                file_get_contents(base_path('resources/js/admin.js'))
+            );
+        }
     }
 
     protected function tearDown(): void

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -34,6 +34,11 @@ class RoutePayloadTest extends TestCase
         })
             ->name('postComments.index');
 
+        $this->router->get('/posts/{post}/comments/{comment:uuid}', function () {
+            return '';
+        })
+            ->name('postComments.show');
+
         $this->router->post('/posts', function () {
             return '';
         })
@@ -59,16 +64,19 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
@@ -87,11 +95,21 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
         ];
 
@@ -112,16 +130,19 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
@@ -142,11 +163,21 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
         ];
 
@@ -168,31 +199,45 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
@@ -215,21 +260,25 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
@@ -246,31 +295,45 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
@@ -291,36 +354,51 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['auth', 'role:admin'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['role:admin'],
             ],
         ];
@@ -342,36 +420,51 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
+            ],
+            'postComments.show' => [
+                'uri' => 'posts/{post}/comments/{comment}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+                'bindings' => [
+                    'comment' => 'uuid',
+                ],
             ],
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['auth'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
         ];

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -8,10 +8,13 @@ use Tightenco\Ziggy\RoutePayload;
 class RoutePayloadTest extends TestCase
 {
     protected $router;
+    protected $laravel7;
 
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->laravel7 = (int) head(explode('.', app()->version())) >= 7;
 
         $this->router = app('router');
         $this->router->get('/home', function () {
@@ -34,11 +37,6 @@ class RoutePayloadTest extends TestCase
         })
             ->name('postComments.index');
 
-        $this->router->get('/posts/{post}/comments/{comment:uuid}', function () {
-            return '';
-        })
-            ->name('postComments.show');
-
         $this->router->post('/posts', function () {
             return '';
         })
@@ -48,6 +46,12 @@ class RoutePayloadTest extends TestCase
             return '';
         })
             ->name('admin.users.index')->middleware('role:admin');
+
+        if ($this->laravel7) {
+            $this->router->get('/posts/{post}/comments/{comment:uuid}', function () {
+                return '';
+            })->name('postComments.show');
+        }
 
         $this->router->getRoutes()->refreshNameLookups();
     }
@@ -64,21 +68,24 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
-                'bindings' => [],
             ],
         ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -95,23 +102,28 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
-            'postComments.show' => [
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -130,21 +142,24 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
-                'bindings' => [],
             ],
         ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -163,23 +178,28 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
-            'postComments.show' => [
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -199,47 +219,48 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
-            'postComments.show' => [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-            'home' => [
-                'uri' => 'home',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'posts.show' => [
-                'uri' => 'posts/{post}',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'posts.store' => [
-                'uri' => 'posts',
-                'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'admin.users.index' => [
-                'uri' => 'admin/users',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -260,27 +281,29 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
-                'bindings' => [],
             ],
         ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -295,47 +318,48 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
             ],
-            'postComments.show' => [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+            ],
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-            'home' => [
-                'uri' => 'home',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'posts.show' => [
-                'uri' => 'posts/{post}',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'posts.store' => [
-                'uri' => 'posts',
-                'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-            'admin.users.index' => [
-                'uri' => 'admin/users',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -354,17 +378,46 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
                 'middleware' => [],
             ],
-            'postComments.show' => [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+                'middleware' => ['auth', 'role:admin'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => ['role:admin'],
+            ],
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
@@ -372,36 +425,8 @@ class RoutePayloadTest extends TestCase
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-            'home' => [
-                'uri' => 'home',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
-            ],
-            'posts.show' => [
-                'uri' => 'posts/{post}',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
-            ],
-            'posts.store' => [
-                'uri' => 'posts',
-                'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => ['auth', 'role:admin'],
-            ],
-            'admin.users.index' => [
-                'uri' => 'admin/users',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => ['role:admin'],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }
@@ -420,17 +445,46 @@ class RoutePayloadTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
-                'bindings' => [],
                 'middleware' => [],
             ],
-            'postComments.show' => [
+            'home' => [
+                'uri' => 'home',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.show' => [
+                'uri' => 'posts/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+            'posts.store' => [
+                'uri' => 'posts',
+                'methods' => ['POST'],
+                'domain' => null,
+                'middleware' => ['auth'],
+            ],
+            'admin.users.index' => [
+                'uri' => 'admin/users',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'middleware' => [],
+            ],
+        ];
+
+        if ($this->laravel7) {
+            foreach ($expected as $key => $route) {
+                $expected[$key]['bindings'] = [];
+            }
+
+            $expected['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
@@ -438,36 +492,8 @@ class RoutePayloadTest extends TestCase
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
-            ],
-            'home' => [
-                'uri' => 'home',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
-            ],
-            'posts.show' => [
-                'uri' => 'posts/{post}',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
-            ],
-            'posts.store' => [
-                'uri' => 'posts',
-                'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => ['auth'],
-            ],
-            'admin.users.index' => [
-                'uri' => 'admin/users',
-                'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
-            ],
-        ];
+            ];
+        }
 
         $this->assertEquals($expected, $routes->toArray());
     }

--- a/tests/Unit/RoutePayloadTest.php
+++ b/tests/Unit/RoutePayloadTest.php
@@ -8,13 +8,10 @@ use Tightenco\Ziggy\RoutePayload;
 class RoutePayloadTest extends TestCase
 {
     protected $router;
-    protected $laravel7;
 
     public function setUp(): void
     {
         parent::setUp();
-
-        $this->laravel7 = (int) head(explode('.', app()->version())) >= 7;
 
         $this->router = app('router');
         $this->router->get('/home', function () {
@@ -47,7 +44,7 @@ class RoutePayloadTest extends TestCase
         })
             ->name('admin.users.index')->middleware('role:admin');
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             $this->router->get('/posts/{post}/comments/{comment:uuid}', function () {
                 return '';
             })->name('postComments.show');
@@ -81,7 +78,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -110,7 +107,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -155,7 +152,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -186,7 +183,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -247,7 +244,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -299,7 +296,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -346,7 +343,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -412,7 +409,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }
@@ -479,7 +476,7 @@ class RoutePayloadTest extends TestCase
             ],
         ];
 
-        if ($this->laravel7) {
+        if ($this->laravelVersion(7)) {
             foreach ($expected as $key => $route) {
                 $expected[$key]['bindings'] = [];
             }

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,5 +1,5 @@
     var Ziggy = {
-        namedRoutes: {"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"],"domain":null}},
+        namedRoutes: {"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"],"domain":null,"bindings":[]}},
         baseUrl: 'http://myapp.com/',
         baseProtocol: 'http',
         baseDomain: 'myapp.com',

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,5 +1,5 @@
     var Ziggy = {
-        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}},
+        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}},
         baseUrl: 'http://example.org/',
         baseProtocol: 'http',
         baseDomain: 'example.org',

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,5 +1,5 @@
     var Ziggy = {
-        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}},
+        namedRoutes: {"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}},
         baseUrl: 'http://myapp.com/',
         baseProtocol: 'http',
         baseDomain: 'myapp.com',

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -97,6 +97,14 @@ global.Ziggy = {
             methods: ['GET', 'HEAD'],
             domain: null
         },
+        'postComments.show': {
+            uri: 'posts/{post}/comments/{comment}',
+            methods: ['GET', 'HEAD'],
+            domain: null,
+            bindings: {
+                comment: 'uuid',
+            },
+        },
     },
     baseUrl: 'http://myapp.dev/',
     baseProtocol: 'http',
@@ -110,6 +118,16 @@ global.Ziggy = {
 describe('route()', function() {
     it('Should return URL when run without params on a route without params', function() {
         assert.equal('http://myapp.dev/posts', route('posts.index'));
+    });
+
+    it('Can use custom route model binding keys', function() {
+        assert.equal(
+            route('postComments.show', [
+                { id: 1, title: 'Post' },
+                { uuid: 12345, title: 'Comment' }
+            ]),
+            'http://myapp.dev/posts/1/comments/12345'
+        );
     });
 
     it('Can handle routing for apps in a subfolder', function() {

--- a/tests/js/test.route.js
+++ b/tests/js/test.route.js
@@ -128,6 +128,14 @@ describe('route()', function() {
             ]),
             'http://myapp.dev/posts/1/comments/12345'
         );
+
+        assert.equal(
+            route('postComments.show', [
+                { id: 1, post: 'Post' },
+                { uuid: 12345, comment: 'Comment' }
+            ]),
+            'http://myapp.dev/posts/1/comments/12345'
+        );
     });
 
     it('Can handle routing for apps in a subfolder', function() {


### PR DESCRIPTION
This PR adds support for [custom scopes in route model bindings](https://laravel.com/docs/7.x/routing#implicit-binding).

Laravel 7 added the ability to scope nested route model bindings on a specific attribute:

```php
// This route will look for a Post using the 'slug' attribute
Route::get('users/{user}/posts/{post:slug}', function (User $user, Post $post) {
    return $post;
})->name('users.posts');
```

Ziggy already supports passing an object parameter and automatically detecting an `id` key if one is present:

```js
route('users.posts', [{ id: 4, name: 'Jacob' }, 'ziggy-v1-announcement'])
// Returns http://example.com/users/4/posts/ziggy-v1-announcement
```

This PR adds support for passing an object as a parameter with a custom binding scope:

```js
route('users.posts', [{ id: 4, name: 'Jacob' }, { published: false, slug: 'ziggy-v1-announcement' }])
// Now also returns http://example.com/users/4/posts/ziggy-v1-announcement
```

Similarly to the existing behaviour with `id`, this only works if there are no conflicting route parameter names, so the example above won't necessarily work if there is another parameter explicitly called just `slug`.