### PR TITLE
Add full support for implicit route model binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Breaking changes are marked with ⚠️.
 **Added**
 
 - Document the `check()` method ([#294](https://github.com/tightenco/ziggy/pull/294)) and how to install and use Ziggy via `npm` and over a CDN ([#299](https://github.com/tightenco/ziggy/pull/299))
-- Add support for [custom scoped route model bindings](https://laravel.com/docs/7.x/routing#implicit-binding), e.g. `/users/{user}/posts/{post:slug}` ([#307](https://github.com/tightenco/ziggy/pull/307))
+- Add support for [custom scoped route model binding](https://laravel.com/docs/7.x/routing#implicit-binding), e.g. `/users/{user}/posts/{post:slug}` ([#307](https://github.com/tightenco/ziggy/pull/307))
+- Add support for [implicit route model binding](https://laravel.com/docs/7.x/routing#implicit-binding) ([#315](https://github.com/tightenco/ziggy/pull/315))
 
 **Changed**
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ route('posts.index'); // Returns '/posts'
 With required parameter:
 
 ```js
-route('posts.show', { id: 1 }); // Returns '/posts/1'
+route('posts.show', { post: 1 }); // Returns '/posts/1'
 route('posts.show', [1]); // Returns '/posts/1'
 route('posts.show', 1); // Returns '/posts/1'
 ```

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -189,14 +189,13 @@ class Ziggy implements JsonSerializable
             $routeBindings = array_map(function ($parameter) {
                 $model = $parameter->getType()->getName();
 
-                if (
-                    (new ReflectionMethod($model, 'getRouteKey'))->class === $model
-                    || (new ReflectionMethod($model, 'getRouteKeyName'))->class === $model
-                ) {
-                    return [$parameter->getName() => app($model)->getRouteKeyName()];
-                } else {
-                    return [$parameter->getName() => 'id'];
-                }
+                $routeKeyDefiners = [
+                    (new ReflectionMethod($model, 'getRouteKey'))->class,
+                    (new ReflectionMethod($model, 'getRouteKeyName'))->class,
+                ];
+
+                // Avoid booting this model if it doesn't override the default route key name
+                return [$parameter->getName() => in_array($model, $routeKeyDefiners) ? app($model)->getRouteKeyName() : 'id'];
             }, $route->signatureParameters(UrlRoutable::class));
 
             if (method_exists($route, 'bindingFields')) {

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -4,7 +4,6 @@ namespace Tightenco\Ziggy;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use JsonSerializable;
 use ReflectionMethod;
@@ -181,7 +180,7 @@ class Ziggy implements JsonSerializable
     }
 
     /**
-     * Resolve route key names for route parameters using Eloquent route model binding.
+     * Resolve route key names for any route parameters using Eloquent route model binding.
      */
     protected function resolveBindings(array $routes): array
     {

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -105,7 +105,7 @@ class Ziggy implements JsonSerializable
                 return $route->isFallback;
             });
 
-        $routes->merge($fallbacks);
+        $routes = $routes->merge($fallbacks);
 
         $implicitBindings = $routes->mapWithKeys(function ($route, $name) {
             $bindings = collect($route->signatureParameters(UrlRoutable::class))

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -106,11 +106,9 @@ class Ziggy implements JsonSerializable
                 return $route->isFallback;
             });
 
-        $routes = $routes->merge($fallbacks);
-
         $bindings = $this->resolveBindings($routes);
 
-        return $routes
+        return $routes->merge($fallbacks)
             ->map(function ($route) use ($bindings) {
                 if ($this->isListedAs($route, 'except')) {
                     $this->appendRouteToList($route->getName(), 'except');
@@ -120,7 +118,7 @@ class Ziggy implements JsonSerializable
 
                 return collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain())
-                    ->put('bindings', $bindings[$route->getName()])
+                    ->put('bindings', $bindings[$route->getName()] ?? [])
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
                         if (is_array($middleware)) {
                             return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());

--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -121,9 +121,6 @@ class Ziggy implements JsonSerializable
                 return collect($route)->only(['uri', 'methods'])
                     ->put('domain', $route->domain())
                     ->put('bindings', $bindings[$route->getName()])
-                    ->when(method_exists($route, 'bindingFields'), function ($collection) use ($route) {
-                        return $collection->put('bindings', array_merge($collection->get('bindings'), $route->bindingFields()));
-                    })
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
                         if (is_array($middleware)) {
                             return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());
@@ -193,6 +190,10 @@ class Ziggy implements JsonSerializable
             $routeBindings = array_map(function ($parameter) {
                 return [$parameter->getName() => app($parameter->getType()->getName())->getRouteKeyName()];
             }, $route->signatureParameters(UrlRoutable::class));
+
+            if (method_exists($route, 'bindingFields')) {
+                $routeBindings = array_merge($routeBindings, [$route->bindingFields()]);
+            }
 
             return [$name => Arr::collapse($routeBindings)];
         })->all();

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -25,7 +25,7 @@ class ZiggyServiceProvider extends ServiceProvider
     protected function registerDirective(BladeCompiler $bladeCompiler)
     {
         $bladeCompiler->directive('routes', function ($group) {
-            return "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+            return app(BladeRouteGenerator::class)->generate($group);
         });
     }
 }

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -25,7 +25,9 @@ class ZiggyServiceProvider extends ServiceProvider
     protected function registerDirective(BladeCompiler $bladeCompiler)
     {
         $bladeCompiler->directive('routes', function ($group) {
-            return app(BladeRouteGenerator::class)->generate($group);
+            return app()->isLocal()
+                ? "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+                : app(BladeRouteGenerator::class)->generate($group);
         });
     }
 }

--- a/src/ZiggyServiceProvider.php
+++ b/src/ZiggyServiceProvider.php
@@ -26,7 +26,7 @@ class ZiggyServiceProvider extends ServiceProvider
     {
         $bladeCompiler->directive('routes', function ($group) {
             return app()->isLocal()
-                ? "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>";
+                ? "<?php echo app('" . BladeRouteGenerator::class . "')->generate({$group}); ?>"
                 : app(BladeRouteGenerator::class)->generate($group);
         });
     }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -91,4 +91,16 @@ class BladeRouteGeneratorTest extends TestCase
             (new BladeRouteGenerator)->generate(false, 'supercalifragilisticexpialidocious')
         );
     }
+
+    /** @test */
+    public function can_compile_routes_directive()
+    {
+        $compiler = app('blade.compiler');
+
+        $script = (new BladeRouteGenerator)->generate();
+
+        BladeRouteGenerator::$generated = false;
+
+        $this->assertSame($script, $compiler->compileString('@routes'));
+    }
 }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -49,12 +49,9 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
-
-        if ($this->laravelVersion(7)) {
-            $expected['postComments.index']['bindings'] = [];
-        }
 
         $this->assertStringContainsString(json_encode($expected), (new BladeRouteGenerator)->generate());
     }
@@ -73,12 +70,9 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
+                'bindings' => [],
             ],
         ];
-
-        if ($this->laravelVersion(7)) {
-            $expected['postComments.index']['bindings'] = [];
-        }
 
         $this->assertStringContainsString(json_encode($expected), (new BladeRouteGenerator)->generate());
     }

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -97,10 +97,10 @@ class BladeRouteGeneratorTest extends TestCase
     {
         $compiler = app('blade.compiler');
 
+        BladeRouteGenerator::$generated = false;
         $script = (new BladeRouteGenerator)->generate();
 
         BladeRouteGenerator::$generated = false;
-
         $this->assertSame($script, $compiler->compileString('@routes'));
     }
 }

--- a/tests/Unit/CommandRouteGeneratorTest.php
+++ b/tests/Unit/CommandRouteGeneratorTest.php
@@ -46,14 +46,7 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate');
 
-        if ($this->laravelVersion(7)) {
-            $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
-        } else {
-            $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/ziggy.js')),
-                file_get_contents(base_path('resources/js/ziggy.js'))
-            );
-        }
+        $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
     }
 
     /** @test */
@@ -65,14 +58,7 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate', ['--url' => 'http://example.org']);
 
-        if ($this->laravelVersion(7)) {
-            $this->assertFileEquals('./tests/fixtures/custom-url.js', base_path('resources/js/ziggy.js'));
-        } else {
-            $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/custom-url.js')),
-                file_get_contents(base_path('resources/js/ziggy.js'))
-            );
-        }
+        $this->assertFileEquals('./tests/fixtures/custom-url.js', base_path('resources/js/ziggy.js'));
     }
 
     /** @test */
@@ -88,14 +74,7 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate');
 
-        if ($this->laravelVersion(7)) {
-            $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
-        } else {
-            $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/ziggy.js')),
-                file_get_contents(base_path('resources/js/ziggy.js'))
-            );
-        }
+        $this->assertFileEquals('./tests/fixtures/ziggy.js', base_path('resources/js/ziggy.js'));
     }
 
     /** @test */
@@ -114,13 +93,6 @@ class CommandRouteGeneratorTest extends TestCase
 
         Artisan::call('ziggy:generate', ['path' => 'resources/js/admin.js', '--group' => 'admin']);
 
-        if ($this->laravelVersion(7)) {
-            $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
-        } else {
-            $this->assertSame(
-                str_replace(',"bindings":[]', '', file_get_contents(__DIR__ . '/../fixtures/admin.js')),
-                file_get_contents(base_path('resources/js/admin.js'))
-            );
-        }
+        $this->assertFileEquals('./tests/fixtures/admin.js', base_path('resources/js/admin.js'));
     }
 }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Tightenco\Ziggy\Ziggy;
+use Tests\TestCase;
+use Tightenco\Ziggy\BladeRouteGenerator;
+
+class RouteModelBindingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $router = app('router');
+
+        $router->get('users/{user}', function (User $user) {
+            return '';
+        })->name('users');
+
+        $router->get('blog/{category}/{post:slug}', function (PostCategory $category, Post $post) {
+            return '';
+        })->name('categories.posts.show');
+
+        // if ($this->laravelVersion(7)) {
+        //     $router->get('/posts/{post}/comments/{comment:uuid}', $this->noop())->name('postComments.show');
+        // }
+
+        $router->getRoutes()->refreshNameLookups();
+    }
+
+    /** @test */
+    public function can_retrieve_implicit_route_model_bindings()
+    {
+        $this->assertSame([
+            'users' => [
+                'uri' => 'users/{user}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'user' => 'uuid',
+                ],
+            ],
+            'categories.posts.show' => [
+                'uri' => 'blog/{category}/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'category' => 'id',
+                    'post' => 'slug',
+                ],
+            ],
+        ], (new Ziggy)->toArray()['namedRoutes']);
+    }
+}
+
+class User extends Model
+{
+    public function getRouteKeyName()
+    {
+        return 'uuid';
+    }
+}
+
+class PostCategory extends Model
+{
+    //
+}
+
+class Post extends Model
+{
+    //
+}

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -28,6 +28,9 @@ class RouteModelBindingTest extends TestCase
             $router->get('blog/{category}/{post:slug}', function (PostCategory $category, Post $post) {
                 return '';
             })->name('posts');
+            $router->get('blog/{category}/{post:slug}/{tag:slug}', function (PostCategory $category, Post $post, Tag $tag) {
+                return '';
+            })->name('posts.tags');
         }
 
         $router->getRoutes()->refreshNameLookups();
@@ -81,6 +84,36 @@ class RouteModelBindingTest extends TestCase
     }
 
     /** @test */
+    public function can_handle_multiple_scoped_bindings()
+    {
+        if (! $this->laravelVersion(7)) {
+            $this->markTestSkipped('Requires Laravel >=7');
+        }
+
+        $this->assertSame([
+            'posts' => [
+                'uri' => 'blog/{category}/{post}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'category' => 'id',
+                    'post' => 'slug',
+                ],
+            ],
+            'posts.tags' => [
+                'uri' => 'blog/{category}/{post}/{tag}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'category' => 'id',
+                    'post' => 'slug',
+                    'tag' => 'slug',
+                ],
+            ],
+        ], (new Ziggy)->filter('posts*')->toArray());
+    }
+
+    /** @test */
     public function can_merge_implicit_and_scoped_bindings()
     {
         if (! $this->laravelVersion(7)) {
@@ -119,6 +152,16 @@ class RouteModelBindingTest extends TestCase
                     'post' => 'slug',
                 ],
             ],
+            'posts.tags' => [
+                'uri' => 'blog/{category}/{post}/{tag}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'category' => 'id',
+                    'post' => 'slug',
+                    'tag' => 'slug',
+                ],
+            ],
         ], (new Ziggy)->toArray()['namedRoutes']);
     }
 }
@@ -137,6 +180,11 @@ class PostCategory extends Model
 }
 
 class Post extends Model
+{
+    //
+}
+
+class Tag extends Model
 {
     //
 }

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -164,6 +164,14 @@ class RouteModelBindingTest extends TestCase
             ],
         ], (new Ziggy)->toArray()['namedRoutes']);
     }
+
+    /** @test */
+    public function can_json_bindings()
+    {
+        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"],"domain":null,"bindings":[]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+
+        $this->assertSame($json, (new Ziggy)->toJson());
+    }
 }
 
 class User extends Model

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -3,10 +3,8 @@
 namespace Tests\Unit;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
-use Tightenco\Ziggy\Ziggy;
 use Tests\TestCase;
-use Tightenco\Ziggy\BladeRouteGenerator;
+use Tightenco\Ziggy\Ziggy;
 
 class RouteModelBindingTest extends TestCase
 {
@@ -19,21 +17,76 @@ class RouteModelBindingTest extends TestCase
         $router->get('users/{user}', function (User $user) {
             return '';
         })->name('users');
-
-        $router->get('blog/{category}/{post:slug}', function (PostCategory $category, Post $post) {
+        $router->get('tokens/{token}', function ($token) {
             return '';
-        })->name('categories.posts.show');
+        })->name('tokens');
+        $router->get('users/{user}/{number}', function (User $user, int $n) {
+            return '';
+        })->name('users.numbers');
 
-        // if ($this->laravelVersion(7)) {
-        //     $router->get('/posts/{post}/comments/{comment:uuid}', $this->noop())->name('postComments.show');
-        // }
+        if ($this->laravelVersion(7)) {
+            $router->get('blog/{category}/{post:slug}', function (PostCategory $category, Post $post) {
+                return '';
+            })->name('posts');
+        }
 
         $router->getRoutes()->refreshNameLookups();
     }
 
     /** @test */
-    public function can_retrieve_implicit_route_model_bindings()
+    public function can_register_implicit_route_model_bindings()
     {
+        $expected = [
+            'users' => [
+                'uri' => 'users/{user}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'user' => 'uuid',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, (new Ziggy)->filter('users')->toArray());
+    }
+
+    /** @test */
+    public function can_ignore_route_parameters_not_bound_to_eloquent_models()
+    {
+        $this->assertSame([
+            'tokens' => [
+                'uri' => 'tokens/{token}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [],
+            ],
+        ], (new Ziggy)->filter(['tokens'])->toArray());
+    }
+
+    /** @test */
+    public function can_handle_bound_and_unbound_params_in_the_same_route()
+    {
+        $expected = [
+            'users.numbers' => [
+                'uri' => 'users/{user}/{number}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'user' => 'uuid',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, (new Ziggy)->filter('users.numbers')->toArray());
+    }
+
+    /** @test */
+    public function can_merge_implicit_and_scoped_bindings()
+    {
+        if (! $this->laravelVersion(7)) {
+            $this->markTestSkipped('Requires Laravel >=7');
+        }
+
         $this->assertSame([
             'users' => [
                 'uri' => 'users/{user}',
@@ -43,7 +96,21 @@ class RouteModelBindingTest extends TestCase
                     'user' => 'uuid',
                 ],
             ],
-            'categories.posts.show' => [
+            'tokens' => [
+                'uri' => 'tokens/{token}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [],
+            ],
+            'users.numbers' => [
+                'uri' => 'users/{user}/{number}',
+                'methods' => ['GET', 'HEAD'],
+                'domain' => null,
+                'bindings' => [
+                    'user' => 'uuid',
+                ],
+            ],
+            'posts' => [
                 'uri' => 'blog/{category}/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -166,8 +166,12 @@ class RouteModelBindingTest extends TestCase
     }
 
     /** @test */
-    public function can_json_bindings()
+    public function can_include_bindings_in_json()
     {
+        if (! $this->laravelVersion(7)) {
+            $this->markTestSkipped('Requires Laravel >=7');
+        }
+
         $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"],"domain":null,"bindings":[]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -28,18 +28,6 @@ class ZiggyTest extends TestCase
     }
 
     /**
-     * If running Laravel 7 or higher, add a 'bindings' key to every route.
-     */
-    protected function addBindings(array &$routes): void
-    {
-        if ($this->laravelVersion(7)) {
-            $routes = array_map(function ($route) {
-                return array_merge($route, ['bindings' => []]);
-            }, $routes);
-        }
-    }
-
-    /**
      * If running Laravel 7 or higher, the 'postComments.show' route.
      */
     protected function addPostCommentsRouteWithBindings(array &$routes): void
@@ -67,20 +55,21 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
-
-        $this->addBindings($expected);
 
         $this->assertSame($expected, $routes->toArray());
     }
@@ -96,15 +85,16 @@ class ZiggyTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
 
         $this->assertSame($expected, $routes->toArray());
@@ -123,20 +113,21 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
-
-        $this->addBindings($expected);
 
         $this->assertSame($expected, $routes);
     }
@@ -154,15 +145,16 @@ class ZiggyTest extends TestCase
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
 
         $this->assertSame($expected, $routes);
@@ -182,35 +174,40 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
 
         $this->assertSame($expected, $routes);
@@ -231,25 +228,27 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
-
-        $this->addBindings($expected);
 
         $this->assertSame($expected, $routes);
     }
@@ -265,35 +264,40 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
 
         $this->assertSame($expected, $routes);
@@ -312,41 +316,46 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['auth', 'role:admin'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['role:admin'],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
         if ($this->laravelVersion(7)) {
             $expected['postComments.show']['middleware'] = [];
@@ -368,41 +377,46 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => ['auth'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
                 'middleware' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
         if ($this->laravelVersion(7)) {
             $expected['postComments.show']['middleware'] = [];
@@ -426,54 +440,55 @@ class ZiggyTest extends TestCase
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
                 'domain' => null,
+                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => null,
+                'bindings' => [],
             ],
         ];
 
-        $this->addBindings($expected);
         $this->addPostCommentsRouteWithBindings($expected);
 
         $expected['users.index'] = [
             'uri' => 'users',
             'methods' => ['GET', 'HEAD'],
             'domain' => null,
+            'bindings' => [],
         ];
-        if ($this->laravelVersion(7)) {
-            $expected['users.index']['bindings'] = [];
-        }
 
         $expected['fallback'] = [
             'uri' => '{fallbackPlaceholder}',
             'methods' => ['GET', 'HEAD'],
             'domain' => null,
+            'bindings' => [],
         ];
-        if ($this->laravelVersion(7)) {
-            $expected['fallback']['bindings'] = [];
-        }
 
         $this->assertSame($expected, $routes);
     }
@@ -494,36 +509,41 @@ class ZiggyTest extends TestCase
                     'uri' => 'home',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
                 'posts.index' => [
                     'uri' => 'posts',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
                 'posts.show' => [
                     'uri' => 'posts/{post}',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
                 'postComments.index' => [
                     'uri' => 'posts/{post}/comments',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
                 'posts.store' => [
                     'uri' => 'posts',
                     'methods' => ['POST'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
                 'admin.users.index' => [
                     'uri' => 'admin/users',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
             ],
         ];
 
-        $this->addBindings($expected['namedRoutes']);
         $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
 
         $this->assertSame($expected, $ziggy->toArray());
@@ -548,22 +568,14 @@ class ZiggyTest extends TestCase
                     'uri' => 'posts/{post}/comments',
                     'methods' => ['GET', 'HEAD'],
                     'domain' => null,
+                    'bindings' => [],
                 ],
             ],
         ];
 
-        $this->addBindings($expected['namedRoutes']);
         $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null}}}';
-
-        if ($this->laravelVersion(7)) {
-            $json = str_replace(
-                '"domain":null}',
-                '"domain":null,"bindings":[]},"postComments.show":{"uri":"posts\/{post}\/comments\/{comment}","methods":["GET","HEAD"],"domain":null,"bindings":{"comment":"uuid"}}',
-                $json,
-            );
-        }
+        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}}}';
 
         $this->assertSame($expected, json_decode(json_encode(new Ziggy), true));
         $this->assertSame($json, json_encode(new Ziggy));

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -577,6 +577,14 @@ class ZiggyTest extends TestCase
 
         $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}}}';
 
+        if ($this->laravelVersion(7)) {
+            $json = str_replace(
+                '"domain":null,"bindings":[]}',
+                '"domain":null,"bindings":[]},"postComments.show":{"uri":"posts\/{post}\/comments\/{comment}","methods":["GET","HEAD"],"domain":null,"bindings":{"comment":"uuid"}}',
+                $json,
+            );
+        }
+
         $this->assertSame($expected, json_decode(json_encode(new Ziggy), true));
         $this->assertSame($json, json_encode(new Ziggy));
         $this->assertSame($json, (new Ziggy)->toJson());


### PR DESCRIPTION
This PR adds support for [implicit route model binding](https://laravel.com/docs/7.x/routing#implicit-binding). It builds on #307, which added support for custom _scoped_ route model bindings defined directly in the route pattern.

When generating Ziggy's list of routes, we'll now resolve _all_ route model bindings and pass them to Ziggy's javascript output. This lays the foundation for making Ziggy's detection of 'model' objects passed in as route parameters way simpler and more powerful. Right now we're sniffing for an `id` property (or a custom binding key _if the parameter is scoped_), but this only works for models with the route key `id`—after this PR, we'll be able to use every model's actual route key name.

Given this model and route...

```php
class User extends Model
{
    public function getRouteKeyName()
    {
        return 'uuid';
    }
}

Route::get('users/{user}', function (User $user) {
    return $user;
})->name('users.show');
```

...Ziggy's `namedRoutes` will now contain an entry that looks like this...

```js
{
    // ...
    'users.show': {
        uri: 'users/{user}',
        methods: ['GET', 'HEAD'],
        domain: null,
        bindings: {
            user: 'uuid', // this is new
        },
    }
}
```

...which means we'll eventually be able to pass a JSON `user` object directly into Ziggy's `route()` function as a parameter, even though that model doesn't use `id` as its route key:

```js
route('users.show', user);
// would return something like 'https://ziggy.dev/users/f7e781fe-9d66-4967-a9b3-39ec609b04f2'
```

This implementation requires reflecting into the parameters of all routes in the application and instantiating an Eloquent model for every bound parameter, which could conceivably have an impact on performance in apps with a lot of routes. This would only become an issue if it happened on every request, so to mitigate that, this PR also changes the `@routes` Blade directive to output Ziggy's javascript directly instead of just embedding a call to our `BladeRouteGenerator`. This means that Ziggy's entire output will be cached automatically inside the application's compiled Blade views. Note that this means users will have to run `php artisan view:clear` after changing any of their routes. I'll add a note about it to the Readme before we release v1.

Huge thanks to @taylorotwell for pointing me in the right direction to get this working!

Closes #308, see also #143 and #301.