### PR TITLE
docs: Add documentation for Content Security Policy param

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Ziggy supports all versions of Laravel from `5.4` to `7.x`.
 - [Filtering Routes](#filtering-routes)
     - [Basic Filtering](#basic-filtering)
     - [Filtering using Groups](#filtering-using-groups)
+- [Content Security Policy](#content-security-policy)
 - [Other Useful Methods](#other-useful-methods)
     - [`current()`](#current)
     - [`check()`](#check)
@@ -170,6 +171,20 @@ If you want to expose multiple groups you can pass an array of group names:
 ```
 
 **Note: Passing group names to the `@routes` directive will always take precedence over your other `only` or `except` settings.**
+
+## Content Security Policy
+
+A Content Security Policy may block unsafe inline scripts which Ziggy uses to pass the routes to JavaScript. By adding a nonce to your CSP you can allow certain inlined scripts. To add this nonce to Ziggy you can pass it as the second argument:
+
+```php
+@routes(false, 'nonce="[YOUR_NONCE]"')
+```
+
+Or if you are using [Spaties CSP Package](https://github.com/spatie/laravel-csp):
+
+```php
+@routes(false, csp_nonce())
+```
 
 ## Other Useful Methods
 

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ If you want to expose multiple groups you can pass an array of group names:
 
 ## Content Security Policy
 
-A Content Security Policy may block unsafe inline scripts which Ziggy uses to pass the routes to JavaScript. By adding a nonce to your CSP you can allow certain inlined scripts. To add this nonce to Ziggy you can pass it as the second argument:
+A [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) may block unsafe inline scripts which Ziggy uses to pass the routes to JavaScript. By adding a nonce to your CSP you can allow certain inlined scripts. To add this nonce to Ziggy you can pass it as the second argument:
 
 ```php
-@routes(false, 'nonce="[YOUR_NONCE]"')
+@routes(false, '[YOUR_NONCE]')
 ```
 
-Or if you are using [Spaties CSP Package](https://github.com/spatie/laravel-csp):
+Or if you are using [Spatie's CSP Package](https://github.com/spatie/laravel-csp):
 
 ```php
 @routes(false, csp_nonce())


### PR DESCRIPTION
Added a section on how to add a CSP nonce with Ziggy. This was only discussed in PRs so far.