### PR TITLE
Filter out null and empty values

### DIFF
--- a/src/Ziggy.php
+++ b/src/Ziggy.php
@@ -121,11 +121,11 @@ class Ziggy implements JsonSerializable
                     ->put('bindings', $bindings[$route->getName()] ?? [])
                     ->when($middleware = config('ziggy.middleware'), function ($collection) use ($middleware, $route) {
                         if (is_array($middleware)) {
-                            return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values());
+                            return $collection->put('middleware', collect($route->middleware())->intersect($middleware)->values()->all());
                         }
 
                         return $collection->put('middleware', $route->middleware());
-                    });
+                    })->filter();
             });
     }
 

--- a/tests/Unit/BladeRouteGeneratorTest.php
+++ b/tests/Unit/BladeRouteGeneratorTest.php
@@ -48,8 +48,6 @@ class BladeRouteGeneratorTest extends TestCase
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -70,7 +68,6 @@ class BladeRouteGeneratorTest extends TestCase
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
                 'domain' => '{account}.myapp.com',
-                'bindings' => [],
             ],
         ];
 

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -46,7 +46,6 @@ class RouteModelBindingTest extends TestCase
             'users' => [
                 'uri' => 'users/{user}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'user' => 'uuid',
                 ],
@@ -63,8 +62,6 @@ class RouteModelBindingTest extends TestCase
             'tokens' => [
                 'uri' => 'tokens/{token}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ], (new Ziggy)->filter(['tokens'])->toArray());
     }
@@ -76,7 +73,6 @@ class RouteModelBindingTest extends TestCase
             'users.numbers' => [
                 'uri' => 'users/{user}/{number}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'user' => 'uuid',
                 ],
@@ -97,7 +93,6 @@ class RouteModelBindingTest extends TestCase
             'posts' => [
                 'uri' => 'blog/{category}/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'category' => 'id',
                     'post' => 'slug',
@@ -106,7 +101,6 @@ class RouteModelBindingTest extends TestCase
             'posts.tags' => [
                 'uri' => 'blog/{category}/{post}/{tag}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'category' => 'id',
                     'post' => 'slug',
@@ -127,7 +121,6 @@ class RouteModelBindingTest extends TestCase
             'users' => [
                 'uri' => 'users/{user}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'user' => 'uuid',
                 ],
@@ -135,7 +128,6 @@ class RouteModelBindingTest extends TestCase
             'tags' => [
                 'uri' => 'tags/{tag}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'tag' => 'id',
                 ],
@@ -143,13 +135,10 @@ class RouteModelBindingTest extends TestCase
             'tokens' => [
                 'uri' => 'tokens/{token}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'users.numbers' => [
                 'uri' => 'users/{user}/{number}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'user' => 'uuid',
                 ],
@@ -157,7 +146,6 @@ class RouteModelBindingTest extends TestCase
             'posts' => [
                 'uri' => 'blog/{category}/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'category' => 'id',
                     'post' => 'slug',
@@ -166,7 +154,6 @@ class RouteModelBindingTest extends TestCase
             'posts.tags' => [
                 'uri' => 'blog/{category}/{post}/{tag}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'category' => 'id',
                     'post' => 'slug',
@@ -183,7 +170,7 @@ class RouteModelBindingTest extends TestCase
             $this->markTestSkipped('Requires Laravel >=7');
         }
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"domain":null,"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"],"domain":null,"bindings":[]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"domain":null,"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"domain":null,"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"users":{"uri":"users\/{user}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"tags":{"uri":"tags\/{tag}","methods":["GET","HEAD"],"bindings":{"tag":"id"}},"tokens":{"uri":"tokens\/{token}","methods":["GET","HEAD"]},"users.numbers":{"uri":"users\/{user}\/{number}","methods":["GET","HEAD"],"bindings":{"user":"uuid"}},"posts":{"uri":"blog\/{category}\/{post}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug"}},"posts.tags":{"uri":"blog\/{category}\/{post}\/{tag}","methods":["GET","HEAD"],"bindings":{"category":"id","post":"slug","tag":"slug"}}}}';
 
         $this->assertSame($json, (new Ziggy)->toJson());
     }

--- a/tests/Unit/ZiggyTest.php
+++ b/tests/Unit/ZiggyTest.php
@@ -36,7 +36,6 @@ class ZiggyTest extends TestCase
             $routes['postComments.show'] = [
                 'uri' => 'posts/{post}/comments/{comment}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
                 'bindings' => [
                     'comment' => 'uuid',
                 ],
@@ -54,20 +53,14 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -84,14 +77,10 @@ class ZiggyTest extends TestCase
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -112,20 +101,14 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -144,14 +127,10 @@ class ZiggyTest extends TestCase
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -173,38 +152,26 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -227,26 +194,18 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -263,38 +222,26 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -315,51 +262,32 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
                 'middleware' => ['auth', 'role:admin'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
                 'middleware' => ['role:admin'],
             ],
         ];
 
         $this->addPostCommentsRouteWithBindings($expected);
-        if ($this->laravelVersion(7)) {
-            $expected['postComments.show']['middleware'] = [];
-        }
 
         $this->assertEquals($expected, $routes);
     }
@@ -376,51 +304,31 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
                 'middleware' => ['auth'],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
-                'middleware' => [],
             ],
         ];
 
         $this->addPostCommentsRouteWithBindings($expected);
-        if ($this->laravelVersion(7)) {
-            $expected['postComments.show']['middleware'] = [];
-        }
 
         $this->assertEquals($expected, $routes);
     }
@@ -439,38 +347,26 @@ class ZiggyTest extends TestCase
             'home' => [
                 'uri' => 'home',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.index' => [
                 'uri' => 'posts',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.show' => [
                 'uri' => 'posts/{post}',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'postComments.index' => [
                 'uri' => 'posts/{post}/comments',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'posts.store' => [
                 'uri' => 'posts',
                 'methods' => ['POST'],
-                'domain' => null,
-                'bindings' => [],
             ],
             'admin.users.index' => [
                 'uri' => 'admin/users',
                 'methods' => ['GET', 'HEAD'],
-                'domain' => null,
-                'bindings' => [],
             ],
         ];
 
@@ -479,15 +375,11 @@ class ZiggyTest extends TestCase
         $expected['users.index'] = [
             'uri' => 'users',
             'methods' => ['GET', 'HEAD'],
-            'domain' => null,
-            'bindings' => [],
         ];
 
         $expected['fallback'] = [
             'uri' => '{fallbackPlaceholder}',
             'methods' => ['GET', 'HEAD'],
-            'domain' => null,
-            'bindings' => [],
         ];
 
         $this->assertSame($expected, $routes);
@@ -508,38 +400,26 @@ class ZiggyTest extends TestCase
                 'home' => [
                     'uri' => 'home',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
                 'posts.index' => [
                     'uri' => 'posts',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
                 'posts.show' => [
                     'uri' => 'posts/{post}',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
                 'postComments.index' => [
                     'uri' => 'posts/{post}/comments',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
                 'posts.store' => [
                     'uri' => 'posts',
                     'methods' => ['POST'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
                 'admin.users.index' => [
                     'uri' => 'admin/users',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
             ],
         ];
@@ -567,20 +447,18 @@ class ZiggyTest extends TestCase
                 'postComments.index' => [
                     'uri' => 'posts/{post}/comments',
                     'methods' => ['GET', 'HEAD'],
-                    'domain' => null,
-                    'bindings' => [],
                 ],
             ],
         ];
 
         $this->addPostCommentsRouteWithBindings($expected['namedRoutes']);
 
-        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}}}';
+        $json = '{"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}}';
 
         if ($this->laravelVersion(7)) {
             $json = str_replace(
-                '"domain":null,"bindings":[]}',
-                '"domain":null,"bindings":[]},"postComments.show":{"uri":"posts\/{post}\/comments\/{comment}","methods":["GET","HEAD"],"domain":null,"bindings":{"comment":"uuid"}}',
+                '}}}',
+                '},"postComments.show":{"uri":"posts\/{post}\/comments\/{comment}","methods":["GET","HEAD"],"bindings":{"comment":"uuid"}}}}',
                 $json,
             );
         }

--- a/tests/fixtures/admin.js
+++ b/tests/fixtures/admin.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"],"domain":null,"bindings":[]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"admin.dashboard":{"uri":"admin","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {

--- a/tests/fixtures/custom-url.js
+++ b/tests/fixtures/custom-url.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/example.org\/","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}}};
+var Ziggy = {"baseUrl":"http:\/\/example.org\/","baseProtocol":"http","baseDomain":"example.org","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {

--- a/tests/fixtures/ziggy.js
+++ b/tests/fixtures/ziggy.js
@@ -1,4 +1,4 @@
-var Ziggy = {"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"],"domain":null,"bindings":[]}}};
+var Ziggy = {"baseUrl":"http:\/\/ziggy.dev\/","baseProtocol":"http","baseDomain":"ziggy.dev","basePort":null,"defaultParameters":[],"namedRoutes":{"postComments.index":{"uri":"posts\/{post}\/comments","methods":["GET","HEAD"]}}};
 
 if (typeof window !== 'undefined' && typeof window.Ziggy !== 'undefined') {
     for (var name in window.Ziggy.namedRoutes) {


### PR DESCRIPTION
This PR filters out `'domain' => null`, `'bindings' => []`, and `'middleware' => []`, which saves a few bytes in the javascript payload and cleans up the tests quite a bit.